### PR TITLE
Supports wildcard parameters

### DIFF
--- a/src/OpenApi/ROAStyleBuilder.php
+++ b/src/OpenApi/ROAStyleBuilder.php
@@ -208,17 +208,17 @@ final readonly class ROAStyleBuilder implements ApiDataBuilder
      */
     private function getWildcardHeader(Parameter $parameter, array $headers): array
     {
-        $value = $this->getParameterRawValue($parameter, $headers);
+        $values = $this->getParameterRawValue($parameter, $headers);
 
-        if (! is_array($value)) {
+        if (! is_array($values)) {
             return [
-                $parameter->name => $this->toHeaderValue($parameter, $value),
+                $parameter->name => $this->toHeaderValue($parameter, $values),
             ];
         }
 
         $result = [];
 
-        foreach ($value as $name => $value) {
+        foreach ($values as $name => $value) {
             $normalized = Str::is($parameter->name, $name)
                 ? $name
                 : Str::fill($parameter->name, $name);

--- a/src/OpenApi/ROAStyleBuilder.php
+++ b/src/OpenApi/ROAStyleBuilder.php
@@ -203,22 +203,22 @@ final readonly class ROAStyleBuilder implements ApiDataBuilder
     }
 
     /**
-     * @param  array<string, string>  $headers
+     * @param  array<string, string>  $values
      * @return array<string, string>
      */
-    private function getWildcardHeader(Parameter $parameter, array $headers): array
+    private function getWildcardHeader(Parameter $parameter, array $values): array
     {
-        $values = $this->getParameterRawValue($parameter, $headers);
+        $headers = $this->getParameterRawValue($parameter, $values);
 
-        if (! is_array($values)) {
+        if (! is_array($headers)) {
             return [
-                $parameter->name => $this->toHeaderValue($parameter, $values),
+                $parameter->name => $this->toHeaderValue($parameter, $headers),
             ];
         }
 
         $result = [];
 
-        foreach ($values as $name => $value) {
+        foreach ($headers as $name => $value) {
             $normalized = Str::is($parameter->name, $name)
                 ? $name
                 : Str::fill($parameter->name, $name);

--- a/src/Str.php
+++ b/src/Str.php
@@ -46,4 +46,24 @@ final class Str
 
         return preg_match("/^$pattern$/", $str) === 1;
     }
+
+    public static function fill(string $mask, string ...$values): string
+    {
+        $size = count($values);
+
+        if ($size === 0) {
+            return $mask;
+        }
+
+        $result = '';
+        $j = 0;
+
+        for ($i = 0; $i < strlen($mask); $i++) {
+            $result .= $mask[$i] === '*' && $j < $size
+                ? $values[$j++]
+                : $mask[$i];
+        }
+
+        return $result;
+    }
 }

--- a/src/Str.php
+++ b/src/Str.php
@@ -39,4 +39,11 @@ final class Str
 
         return str_replace(' ', '', $result);
     }
+
+    public static function is(string $mask, string $str): bool
+    {
+        $pattern = str_replace(preg_quote('*'), '.*', preg_quote($mask));
+
+        return preg_match("/^$pattern$/", $str) === 1;
+    }
 }

--- a/tests/StrTest.php
+++ b/tests/StrTest.php
@@ -59,4 +59,30 @@ final class StrTest extends TestCase
     {
         $this->assertSame($expected, Str::studly($str));
     }
+
+    #[TestWith(['foo*', 'foobar', true])]
+    #[TestWith(['foo*', 'foo', true])]
+    #[TestWith(['foo*', 'bar', false])]
+    #[TestWith(['foo*', 'fo', false])]
+    #[TestWith(['*bar', 'bar', true])]
+    #[TestWith(['*bar', 'foobar', true])]
+    #[TestWith(['foo*baz', 'foobaz', true])]
+    #[TestWith(['foo*baz', 'foobarbaz', true])]
+    #[TestWith(['foo*baz', 'foobar', false])]
+    #[TestWith(['foo', 'foo', true])]
+    #[TestWith(['foo', 'bar', false])]
+    #[TestWith(['foo', 'fo', false])]
+    #[TestWith(['bar*', 'foobar', false])]
+    #[TestWith(['bar', 'foobarbaz', false])]
+    #[TestWith(['foo?', 'foo?', true])]
+    #[TestWith(['foo?', 'foo', false])]
+    #[TestWith(['*', 'bar', true])]
+    #[TestWith(['*', '', true])]
+    #[TestWith(['**', '', true])]
+    #[TestWith(['foo**baz', 'foobaz', true])]
+    #[TestWith(['foo**baz', 'foobarbaz', true])]
+    public function test_is(string $mask, string $str, bool $expected): void
+    {
+        $this->assertSame($expected, Str::is($mask, $str));
+    }
 }

--- a/tests/StrTest.php
+++ b/tests/StrTest.php
@@ -85,4 +85,20 @@ final class StrTest extends TestCase
     {
         $this->assertSame($expected, Str::is($mask, $str));
     }
+
+    /**
+     * @param  string[]  $values
+     */
+    #[TestWith(['foo*', ['bar'], 'foobar'])]
+    #[TestWith(['*bar', ['foo'], 'foobar'])]
+    #[TestWith(['f*o', ['o'], 'foo'])]
+    #[TestWith(['*, *!', ['Hello', 'World'], 'Hello, World!'])]
+    #[TestWith(['*', [], '*'])]
+    #[TestWith(['*', ['foo'], 'foo'])]
+    #[TestWith(['*', ['foo', 'bar'], 'foo'])]
+    #[TestWith(['**', [], '**'])]
+    public function test_fill(string $mask, array $values, string $expected): void
+    {
+        $this->assertSame($expected, Str::fill($mask, ...$values));
+    }
 }


### PR DESCRIPTION
The OSS `PutObject` API includes a parameter named `x-oss-meta-*`. In the example code provided, the `author` and `category` fields will be expanded and included in the HTTP request headers as `x-oss-meta-author` and `x-oss-meta-category`, respectively.

```php
$client->putObject([
    'bucket' => 'mybucket',
    'key' => 'greeting.txt',
    'body' => 'Hello, World!',
    'x-oss-meta-*' => [
        'author' => 'lizhineng',
        'category' => 'notes',
    ],
    '@headers' => [
        'Content-Type' => 'text/plain',
    ],
]);

```

Closes #10.

Reference: https://api.aliyun.com/document/Oss/2019-05-17/PutObject