### PR TITLE
Fix missing content-type when request contains payload

### DIFF
--- a/src/OpenApi/ROAStyleBuilder.php
+++ b/src/OpenApi/ROAStyleBuilder.php
@@ -273,15 +273,11 @@ final readonly class ROAStyleBuilder implements ApiDataBuilder
             return $headers;
         }
 
-        $contentType = match ($parameter->style) {
+        $headers['Content-Type'] = match ($parameter->style) {
             'json' => 'application/json',
             'xml' => 'application/xml',
-            default => null,
+            default => 'application/octet-stream',
         };
-
-        if (is_string($contentType)) {
-            $headers['Content-Type'] = $contentType;
-        }
 
         return $headers;
     }

--- a/src/OpenApi/ROAStyleBuilder.php
+++ b/src/OpenApi/ROAStyleBuilder.php
@@ -114,7 +114,9 @@ final readonly class ROAStyleBuilder implements ApiDataBuilder
                     break;
                 case ParameterLocation::BODY:
                     $body = $this->getParameterValue($parameter, $value);
-                    $headers = $this->addContentTypeIfNeeded($headers, $parameter, $body);
+                    if ($body !== '') {
+                        $headers['Content-Type'] = $this->getContentType($parameter);
+                    }
                     break;
                 default:
                     throw new InvalidArgumentException(
@@ -263,22 +265,12 @@ final readonly class ROAStyleBuilder implements ApiDataBuilder
         return $value;
     }
 
-    /**
-     * @param  array<string, string>  $headers
-     * @return array<string, string>
-     */
-    private function addContentTypeIfNeeded(array $headers, Parameter $parameter, string $value): array
+    private function getContentType(Parameter $parameter): string
     {
-        if ($value === '') {
-            return $headers;
-        }
-
-        $headers['Content-Type'] = match ($parameter->style) {
+        return match ($parameter->style) {
             'json' => 'application/json',
             'xml' => 'application/xml',
             default => 'application/octet-stream',
         };
-
-        return $headers;
     }
 }

--- a/tests/OpenApi/ROAStyleBuilderTest.php
+++ b/tests/OpenApi/ROAStyleBuilderTest.php
@@ -208,6 +208,25 @@ final class ROAStyleBuilderTest extends TestCase
         $this->assertSame('application/json', $data->headers['Content-Type']);
     }
 
+    public function test_headers_resolution_default_content_type(): void
+    {
+        $docs = $this->makeApiDocs();
+        $api = $this->makeApi([
+            'parameters' => [[
+                'name' => 'body',
+                'in' => 'body',
+                'schema' => [
+                    'type' => 'string',
+                    'format' => 'binary',
+                ],
+            ]],
+        ]);
+        $builder = new ROAStyleBuilder($docs, $api);
+        $data = $builder->build(['body' => 'foo']);
+        $this->assertArrayHasKey('Content-Type', $data->headers);
+        $this->assertSame('application/octet-stream', $data->headers['Content-Type']);
+    }
+
     public function test_headers_resolution_content_type_if_body_empty(): void
     {
         $docs = $this->makeApiDocs();


### PR DESCRIPTION
Per RFC 9110 _HTTP Semantics_:

> A sender that generates a message containing content SHOULD generate a Content-Type header field in that message unless the intended media type of the enclosed representation is unknown to the sender. If a Content-Type header field is not present, the recipient MAY either assume a media type of "application/octet-stream" ([[RFC2046](https://www.rfc-editor.org/rfc/rfc9110.html#RFC2046)], [Section 4.5.1](https://www.rfc-editor.org/rfc/rfc2046#section-4.5.1)) or examine the data to determine its type.