### PR TITLE
OSS: Add Content-Length header even if request body is empty

### DIFF
--- a/src/AcsClient.php
+++ b/src/AcsClient.php
@@ -118,6 +118,7 @@ abstract class AcsClient
             new Plugins\ConfigureUserAgent(),
             new Plugins\ConfigureAction($this->docs, $api, $this->streamFactory, $arguments),
             new HeaderSetPlugin(is_array($arguments['@headers'] ?? null) ? $arguments['@headers'] : []),
+            new Plugins\ExecuteSigningHook($this),
             new Plugins\SignRequest($this->docs, $api, $this->config, $arguments),
         ]);
 

--- a/src/Plugins/ExecuteSigningHook.php
+++ b/src/Plugins/ExecuteSigningHook.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dew\Acs\Plugins;
+
+use Dew\Acs\AcsClient;
+use Dew\Acs\WithSigngingHook;
+use Http\Client\Common\Plugin;
+use Http\Promise\Promise;
+use Override;
+use Psr\Http\Message\RequestInterface;
+
+final readonly class ExecuteSigningHook implements Plugin
+{
+    public function __construct(
+        private AcsClient $client
+    ) {
+        //
+    }
+
+    /**
+     * @param  callable(\Psr\Http\Message\RequestInterface): \Http\Promise\Promise  $next
+     * @param  callable(\Psr\Http\Message\RequestInterface): \Http\Promise\Promise  $first
+     */
+    #[Override]
+    public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
+    {
+        if ($this->client instanceof WithSigngingHook) {
+            $request = $this->client->handleSignging($request);
+        }
+
+        return $next($request);
+    }
+}

--- a/src/WithSigngingHook.php
+++ b/src/WithSigngingHook.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dew\Acs;
+
+use Psr\Http\Message\RequestInterface;
+
+interface WithSigngingHook
+{
+    public function handleSignging(RequestInterface $request): RequestInterface;
+}

--- a/tests/Oss/OssClientTest.php
+++ b/tests/Oss/OssClientTest.php
@@ -36,6 +36,15 @@ final class OssClientTest extends TestCase
         $this->assertStringContainsString('x-oss-additional-headers=host%3Bx-foo', $url);
     }
 
+    public function test_content_length_body_empty(): void
+    {
+        $httpClient = new Client();
+        $client = $this->makeClient(['http_client' => $httpClient]);
+        $client->putObject(['bucket' => 'mybucket', 'key' => 'greeting.txt']);
+        $request = $httpClient->getLastRequest();
+        $this->assertSame('0', $request->getHeaderLine('Content-Length'));
+    }
+
     /**
      * @param  TConfig|array<string, mixed>  $config
      */


### PR DESCRIPTION
- Add the ability for the client to modify the HTTP request right before sealing it with the signing hook (`WithSigngingHook` contract).

Closes #15.