### PR TITLE
Tablestore/OTS SDK

### DIFF
--- a/build/annotate-clients.php
+++ b/build/annotate-clients.php
@@ -13,7 +13,7 @@ function getProducts(): array
     $filename = __DIR__.'/../data/products.php';
 
     if (! file_exists($filename)) {
-        throw new RuntimeException('Could not find products data.');
+        throw new RuntimeException('Could not find product data.');
     }
 
     return require $filename;
@@ -54,8 +54,12 @@ function getDocsPaths(array $product): array
     return $paths;
 }
 
-foreach (getProducts() as $product) {
-    printf("=> Annonate %s\n", $product['code']);
+/**
+ * @param  array{code: string, versions: string[]}  $product
+ */
+function annoate(array $product): void
+{
+    printf('=> Annonate %s'.PHP_EOL, $product['code']);
 
     $docs = getDocsPaths($product);
 
@@ -63,4 +67,22 @@ foreach (getProducts() as $product) {
     $annotationBuilder->annotate();
 }
 
-printf("== Annotated successfully.\n");
+function main(): int
+{
+    $products = getProducts();
+
+    foreach ($products as $product) {
+        annoate($product);
+    }
+
+    annoate(['code' => 'Tablestore', 'versions' => ['2020-12-09']]);
+
+    echo '== Annotated successfully.'.PHP_EOL;
+
+    return 0;
+}
+
+/**
+ * Main entry.
+ */
+main();

--- a/build/annotate-clients.php
+++ b/build/annotate-clients.php
@@ -76,6 +76,7 @@ function main(): int
     }
 
     annoate(['code' => 'Tablestore', 'versions' => ['2020-12-09']]);
+    annoate(['code' => 'Ots', 'versions' => ['2016-06-20']]);
 
     echo '== Annotated successfully.'.PHP_EOL;
 

--- a/build/build-clients.php
+++ b/build/build-clients.php
@@ -42,6 +42,7 @@ function main(): void
 {
     buildFromProducts(__DIR__.'/../data/products.php');
     buildProduct('Tablestore');
+    buildProduct('Ots');
     print '== Build completed.'.PHP_EOL;
 }
 

--- a/build/build-clients.php
+++ b/build/build-clients.php
@@ -7,23 +7,45 @@ require_once __DIR__.'/ProductBuilder.php';
 
 use Dew\Acs\ApiDocsResolver;
 
-if (! file_exists(__DIR__.'/../data/products.json')) {
-    throw new RuntimeException('Missing products meta file.');
-}
-
-$products = require __DIR__.'/../data/products.php';
-
-foreach ($products as $product) {
-    printf("=> Build %s\n", strtolower($product['code']));
-
+function buildClient(string $product): void
+{
     $builder = new ProductBuilder(
         basePath: __DIR__.'/../src',
         namespace: 'Dew\\Acs',
-        product: ApiDocsResolver::getNormalizedProductName($product['code'])
+        product: ApiDocsResolver::getNormalizedProductName($product)
     );
 
     $builder->buildClient();
     $builder->buildException();
 }
 
-print "== Build completed.\n";
+function buildFromProducts(string $filename): void
+{
+    if (! file_exists($filename)) {
+        throw new InvalidArgumentException('The file does not exist.');
+    }
+
+    $products = require $filename;
+
+    foreach ($products as $product) {
+        buildProduct($product['code']);
+    }
+}
+
+function buildProduct(string $product): void
+{
+    printf('=> Build %s'.PHP_EOL, strtolower($product));
+    buildClient($product);
+}
+
+function main(): void
+{
+    buildFromProducts(__DIR__.'/../data/products.php');
+    buildProduct('Tablestore');
+    print '== Build completed.'.PHP_EOL;
+}
+
+/**
+ * Main entry.
+ */
+main();

--- a/build/build-clients.php
+++ b/build/build-clients.php
@@ -27,7 +27,15 @@ function buildFromProducts(string $filename): void
 
     $products = require $filename;
 
+    if (! is_array($products)) {
+        throw new RuntimeException('The product data is invalid.');
+    }
+
     foreach ($products as $product) {
+        if (! isset($product['code']) || ! is_string($product['code'])) {
+            throw new RuntimeException('Missing product code.');
+        }
+
         buildProduct($product['code']);
     }
 }

--- a/build/fetch-meta.php
+++ b/build/fetch-meta.php
@@ -224,6 +224,25 @@ function main(): int
         'UpdateInstance',
     ]);
 
+    // @see https://github.com/aliyun/alibabacloud-sdk/blob/f41eec35b536eb2ee7eb1e2467eac88af904dd58/ots-20160620/async/api-info.json
+    buildFromChangeset('Ots', '2016-06-20', 'RPC', [
+        'BindInstance2Vpc',
+        'DeleteInstance',
+        'DeleteTags',
+        'GetInstance',
+        'GetOtsServiceStatus',
+        'InsertInstance',
+        'InsertTags',
+        'ListClusterType',
+        'ListInstance',
+        'ListTags',
+        'ListVpcInfoByInstance',
+        'ListVpcInfoByVpc',
+        'OpenOtsService',
+        'UnbindInstance2Vpc',
+        'UpdateInstance',
+    ]);
+
     echo '== Process completed.'.PHP_EOL;
 
     return 0;

--- a/build/fetch-meta.php
+++ b/build/fetch-meta.php
@@ -2,34 +2,234 @@
 
 declare(strict_types=1);
 
-$metaPath = __DIR__.'/../data/products.json';
+require_once __DIR__.'/../vendor/autoload.php';
 
-if (! file_exists($metaPath)) {
-    throw new RuntimeException('Missing products meta file.');
+use Symfony\Component\VarExporter\VarExporter;
+
+/**
+ * @return string JSON string.
+ */
+function getApiDocs(string $product, string $version): string
+{
+    $url = sprintf(
+        'https://api.aliyun.com/meta/v1/products/%s/versions/%s/api-docs.json',
+        $product, $version
+    );
+
+    $stream = fopen($url, 'r');
+
+    if ($stream === false) {
+        throw new RuntimeException('Could not retrieve the URL: '.$url);
+    }
+
+    $contents = stream_get_contents($stream);
+    fclose($stream);
+
+    if ($contents === false) {
+        throw new RuntimeException('Could not retrieve the data: '.$url);
+    }
+
+    return $contents;
 }
 
-$products = json_decode(
-    file_get_contents($metaPath),
-    associative: true
-);
+/**
+ * @return mixed[]
+ */
+function getLatestApiChanges(string $product, string $version, string $api): array
+{
+    $uri = sprintf('https://api.aliyun.com/api/changeset/%s/%s/%s?page=1&pageSize=1',
+        $product, $version, $api
+    );
 
-foreach ($products as $product) {
-    foreach ($product['versions'] as $version) {
-        printf("=> Processing %s %s\n", $product['code'], $version);
+    $handle = fopen($uri, 'r');
 
-        $url = sprintf('https://api.aliyun.com/meta/v1/products/%s/versions/%s/api-docs.json', $product['code'], $version);
-        $stream = fopen($url, 'r');
-        $contents = stream_get_contents($stream);
-        fclose($stream);
+    if ($handle === false) {
+        throw new RuntimeException("Could not get the $api API.");
+    }
 
-        $direcotry = __DIR__.'/../data/'.strtolower($product['code']).'/'.$version;
+    $contents = stream_get_contents($handle);
 
-        if (! is_dir($direcotry)) {
-            mkdir($direcotry, 0755, recursive: true);
+    if ($contents === false) {
+        throw new RuntimeException("The $api API metadata is missing.");
+    }
+
+    fclose($handle);
+
+    $decoded = json_decode($contents, associative: true, flags: JSON_THROW_ON_ERROR);
+
+    if (! is_array($decoded)) {
+        throw new RuntimeException("Could not parse $api API metadata.");
+    }
+
+    return $decoded;
+}
+
+function failToGetChangeset(string $api, string $message): RuntimeException
+{
+    return new RuntimeException(sprintf(
+        'Could not get the %s API changes: %s',
+        $api, $message
+    ));
+}
+
+function getDirectory(string $product, string $version): string
+{
+    return sprintf(__DIR__.'/../data/%s/%s', strtolower($product), $version);
+}
+
+/**
+ * @param  string[]  $apis
+ * @return array<string, mixed>
+ */
+function buildApiDocsFromChangeset(string $product, string $version, string $style, array $apis): array
+{
+    $docs = [
+        'version' => '1.0',
+        'info' => [
+            'style' => $style,
+            'product' => $product,
+            'version' => $version,
+        ],
+        'directories' => [],
+        'components' => [
+            'schema' => [],
+        ],
+        'apis' => [],
+        'endpoints' => [],
+    ];
+
+    foreach ($apis as $api) {
+        $changeSet = getLatestApiChanges($product, $version, $api);
+
+        if (! isset($changeSet['code']) || $changeSet['code'] !== 0) {
+            throw failToGetChangeset($api, 'status code indicates unsuccessful.');
         }
 
-        file_put_contents($direcotry.'/api-docs.json', $contents);
+        if (! isset($changeSet['data']['count']) || $changeSet['data']['count'] === 0) {
+            throw failToGetChangeset($api, 'count is zero.');
+        }
+
+        if (! isset($changeSet['data']['list'][0]) || ! is_array($changeSet['data']['list'][0])) {
+            throw failToGetChangeset($api, 'the list is empty.');
+        }
+
+        if (! isset($changeSet['data']['list'][0]['current']['apis']) ||
+            ! is_array($changeSet['data']['list'][0]['current']['apis'])) {
+            throw failToGetChangeset($api, 'missing the current data.');
+        }
+
+        $docs['apis'] = [...$docs['apis'], ...$changeSet['data']['list'][0]['current']['apis']];
+    }
+
+    return $docs;
+}
+
+function writeToJson(string $product, string $version, string $contents): void
+{
+    $direcotry = getDirectory($product, $version);
+
+    if (! is_dir($direcotry)) {
+        mkdir($direcotry, 0755, recursive: true);
+    }
+
+    if (file_put_contents($direcotry.'/api-docs.json', $contents) === false) {
+        throw new RuntimeException(sprintf(
+            'Could not persist the API docs for %s with version %s.',
+            $product, $version
+        ));
     }
 }
 
-printf("== Process completed.\n");
+/**
+ * @param  mixed[]  $contents
+ */
+function writeToPhp(string $product, string $version, array $contents): void
+{
+    $direcotry = getDirectory($product, $version);
+
+    if (! is_dir($direcotry)) {
+        mkdir($direcotry, 0755, recursive: true);
+    }
+
+    $code = sprintf('<?php return %s;', VarExporter::export($contents));
+
+    if (file_put_contents($direcotry.'/api-docs.php', $code) === false) {
+        throw new RuntimeException(sprintf(
+            'Could not persist the API docs for %s with version %s.',
+            $product, $version
+        ));
+    }
+}
+
+function buildFromProducts(): void
+{
+    $filename = __DIR__.'/../data/products.json';
+
+    if (! file_exists($filename)) {
+        throw new RuntimeException('Missing product data.');
+    }
+
+    $contents = file_get_contents($filename);
+
+    if ($contents === false) {
+        throw new RuntimeException('Could not read product data.');
+    }
+
+    $products = json_decode(
+        $contents, associative: true, flags: JSON_THROW_ON_ERROR
+    );
+
+    if (! is_array($products)) {
+        throw new RuntimeException('Product data is expected to be a list.');
+    }
+
+    foreach ($products as $product) {
+        foreach ($product['versions'] as $version) {
+            printf('=> Processing %s %s'.PHP_EOL, $product['code'], $version);
+
+            $contents = getApiDocs($product['code'], $version);
+
+            writeToJson($product['code'], $version, $contents);
+        }
+    }
+}
+
+/**
+ * @param  string[]  $apis
+ */
+function buildFromChangeset(string $product, string $version, string $style, array $apis): void
+{
+    printf('=> Processing %s %s'.PHP_EOL, $product, $version);
+
+    $docs = buildApiDocsFromChangeset($product, $version, $style, $apis);
+
+    writeToPhp($product, $version, $docs);
+}
+
+function main(): int
+{
+    buildFromProducts();
+
+    // @see https://github.com/aliyun/alibabacloud-sdk/blob/64968f246b2537b00109cc1452c3a641f2795739/tablestore-20201209/async/api-info.json
+    buildFromChangeset('Tablestore', '2020-12-09', 'ROA', [
+        'ChangeResourceGroup',
+        'CreateInstance',
+        'DeleteInstance',
+        'DescribeRegions',
+        'GetInstance',
+        'ListInstances',
+        'ListTagResources',
+        'TagResources',
+        'UntagResources',
+        'UpdateInstance',
+    ]);
+
+    echo '== Process completed.'.PHP_EOL;
+
+    return 0;
+}
+
+/**
+ * Main entry.
+ */
+main();

--- a/data/ots/2016-06-20/api-docs.php
+++ b/data/ots/2016-06-20/api-docs.php
@@ -1,0 +1,1120 @@
+<?php return [
+    'version' => '1.0',
+    'info' => [
+        'style' => 'RPC',
+        'product' => 'Ots',
+        'version' => '2016-06-20',
+    ],
+    'directories' => [],
+    'components' => [
+        'schema' => [],
+    ],
+    'apis' => [
+        'BindInstance2Vpc' => [
+            'deprecated' => false,
+            'methods' => [
+                'post',
+            ],
+            'operationType' => 'readAndWrite',
+            'parameters' => [
+                [
+                    'in' => 'query',
+                    'name' => 'VpcId',
+                    'schema' => [
+                        'required' => true,
+                        'type' => 'string',
+                    ],
+                ],
+                [
+                    'in' => 'query',
+                    'name' => 'VirtualSwitchId',
+                    'schema' => [
+                        'required' => true,
+                        'type' => 'string',
+                    ],
+                ],
+                [
+                    'in' => 'query',
+                    'name' => 'InstanceName',
+                    'schema' => [
+                        'required' => true,
+                        'type' => 'string',
+                    ],
+                ],
+                [
+                    'in' => 'query',
+                    'name' => 'InstanceVpcName',
+                    'schema' => [
+                        'required' => true,
+                        'type' => 'string',
+                    ],
+                ],
+                [
+                    'in' => 'query',
+                    'name' => 'RegionNo',
+                    'schema' => [
+                        'required' => false,
+                        'type' => 'string',
+                    ],
+                ],
+                [
+                    'in' => 'query',
+                    'name' => 'Network',
+                    'schema' => [
+                        'required' => false,
+                        'type' => 'string',
+                    ],
+                ],
+            ],
+            'responses' => [
+                200 => [
+                    'schema' => [
+                        'properties' => [
+                            'Domain' => [
+                                'type' => 'string',
+                            ],
+                            'Endpoint' => [
+                                'type' => 'string',
+                            ],
+                            'RequestId' => [
+                                'type' => 'string',
+                            ],
+                        ],
+                        'type' => 'object',
+                    ],
+                ],
+            ],
+            'schemes' => [
+                'http',
+                'https',
+            ],
+            'security' => [
+                [
+                    'AK' => [],
+                ],
+            ],
+        ],
+        'DeleteInstance' => [
+            'deprecated' => false,
+            'methods' => [
+                'post',
+            ],
+            'operationType' => 'readAndWrite',
+            'parameters' => [
+                [
+                    'in' => 'query',
+                    'name' => 'InstanceName',
+                    'schema' => [
+                        'required' => true,
+                        'type' => 'string',
+                    ],
+                ],
+            ],
+            'responses' => [
+                200 => [
+                    'schema' => [
+                        'properties' => [
+                            'RequestId' => [
+                                'type' => 'string',
+                            ],
+                        ],
+                        'type' => 'object',
+                    ],
+                ],
+            ],
+            'schemes' => [
+                'http',
+                'https',
+            ],
+            'security' => [
+                [
+                    'AK' => [],
+                ],
+            ],
+        ],
+        'DeleteTags' => [
+            'deprecated' => false,
+            'methods' => [
+                'post',
+            ],
+            'operationType' => 'readAndWrite',
+            'parameters' => [
+                [
+                    'in' => 'query',
+                    'name' => 'InstanceName',
+                    'schema' => [
+                        'required' => true,
+                        'type' => 'string',
+                    ],
+                ],
+                [
+                    'in' => 'query',
+                    'name' => 'TagInfo',
+                    'schema' => [
+                        'items' => [
+                            'properties' => [
+                                'TagKey' => [
+                                    'type' => 'string',
+                                ],
+                                'TagValue' => [
+                                    'type' => 'string',
+                                ],
+                            ],
+                            'type' => 'object',
+                        ],
+                        'maxItems' => 5,
+                        'required' => false,
+                        'type' => 'array',
+                    ],
+                    'style' => 'repeatList',
+                ],
+            ],
+            'responses' => [
+                200 => [
+                    'schema' => [
+                        'properties' => [
+                            'RequestId' => [
+                                'type' => 'string',
+                            ],
+                        ],
+                        'type' => 'object',
+                    ],
+                ],
+            ],
+            'schemes' => [
+                'http',
+                'https',
+            ],
+            'security' => [
+                [
+                    'AK' => [],
+                ],
+            ],
+        ],
+        'GetInstance' => [
+            'deprecated' => false,
+            'methods' => [
+                'get',
+            ],
+            'operationType' => 'read',
+            'parameters' => [
+                [
+                    'in' => 'query',
+                    'name' => 'InstanceName',
+                    'schema' => [
+                        'required' => true,
+                        'type' => 'string',
+                    ],
+                ],
+            ],
+            'responses' => [
+                200 => [
+                    'schema' => [
+                        'properties' => [
+                            'InstanceInfo' => [
+                                'properties' => [
+                                    'ClusterType' => [
+                                        'type' => 'string',
+                                    ],
+                                    'CreateTime' => [
+                                        'type' => 'string',
+                                    ],
+                                    'Description' => [
+                                        'type' => 'string',
+                                    ],
+                                    'InstanceName' => [
+                                        'type' => 'string',
+                                    ],
+                                    'Network' => [
+                                        'type' => 'string',
+                                    ],
+                                    'Quota' => [
+                                        'properties' => [
+                                            'EntityQuota' => [
+                                                'format' => 'int32',
+                                                'type' => 'integer',
+                                            ],
+                                        ],
+                                        'type' => 'object',
+                                    ],
+                                    'ReadCapacity' => [
+                                        'format' => 'int32',
+                                        'type' => 'integer',
+                                    ],
+                                    'Status' => [
+                                        'format' => 'int32',
+                                        'type' => 'integer',
+                                    ],
+                                    'TagInfos' => [
+                                        'items' => [
+                                            'properties' => [
+                                                'TagKey' => [
+                                                    'type' => 'string',
+                                                ],
+                                                'TagValue' => [
+                                                    'type' => 'string',
+                                                ],
+                                            ],
+                                            'type' => 'object',
+                                        ],
+                                        'type' => 'array',
+                                    ],
+                                    'UserId' => [
+                                        'type' => 'string',
+                                    ],
+                                    'WriteCapacity' => [
+                                        'format' => 'int32',
+                                        'type' => 'integer',
+                                    ],
+                                ],
+                                'type' => 'object',
+                            ],
+                            'RequestId' => [
+                                'type' => 'string',
+                            ],
+                        ],
+                        'type' => 'object',
+                    ],
+                ],
+            ],
+            'schemes' => [
+                'http',
+                'https',
+            ],
+            'security' => [
+                [
+                    'AK' => [],
+                ],
+            ],
+        ],
+        'GetOtsServiceStatus' => [
+            'deprecated' => false,
+            'errorCodes' => [
+                400 => [
+                    [
+                        'errorCode' => 'IdempotentParameterMismatch',
+                        'errorMessage' => 'The request uses the same client token as a previous, but non-identical request. Do not reuse a client token with different requests, unless the requests are identical.',
+                    ],
+                ],
+            ],
+            'methods' => [
+                'get',
+            ],
+            'operationType' => 'read',
+            'parameters' => [],
+            'responses' => [
+                200 => [
+                    'schema' => [
+                        'properties' => [
+                            'Data' => [
+                                'title' => 'data',
+                                'type' => 'boolean',
+                            ],
+                            'DynamicCode' => [
+                                'title' => 'dynamicCode',
+                                'type' => 'string',
+                            ],
+                            'DynamicMessage' => [
+                                'title' => 'dynamicMessage',
+                                'type' => 'string',
+                            ],
+                            'ErrCode' => [
+                                'title' => 'errCode',
+                                'type' => 'string',
+                            ],
+                            'HttpStatusCode' => [
+                                'format' => 'int32',
+                                'title' => 'httpStatusCode',
+                                'type' => 'integer',
+                            ],
+                            'Message' => [
+                                'title' => 'message',
+                                'type' => 'string',
+                            ],
+                            'RequestId' => [
+                                'title' => 'requestId',
+                                'type' => 'string',
+                            ],
+                            'Success' => [
+                                'title' => 'success',
+                                'type' => 'boolean',
+                            ],
+                        ],
+                        'title' => 'result',
+                        'type' => 'object',
+                    ],
+                ],
+            ],
+            'schemes' => [
+                'http',
+                'https',
+            ],
+            'security' => [
+                [
+                    'AK' => [],
+                ],
+                [
+                    'BearerToken' => [],
+                ],
+            ],
+            'summary' => '获取表格存储开服状态',
+        ],
+        'InsertInstance' => [
+            'deprecated' => false,
+            'methods' => [
+                'post',
+            ],
+            'operationType' => 'write',
+            'parameters' => [
+                [
+                    'in' => 'query',
+                    'name' => 'InstanceName',
+                    'schema' => [
+                        'required' => true,
+                        'type' => 'string',
+                    ],
+                ],
+                [
+                    'in' => 'query',
+                    'name' => 'ClusterType',
+                    'schema' => [
+                        'required' => false,
+                        'type' => 'string',
+                    ],
+                ],
+                [
+                    'in' => 'query',
+                    'name' => 'Network',
+                    'schema' => [
+                        'required' => false,
+                        'type' => 'string',
+                    ],
+                ],
+                [
+                    'in' => 'query',
+                    'name' => 'Description',
+                    'schema' => [
+                        'required' => false,
+                        'type' => 'string',
+                    ],
+                ],
+                [
+                    'in' => 'query',
+                    'name' => 'TagInfo',
+                    'schema' => [
+                        'items' => [
+                            'properties' => [
+                                'TagKey' => [
+                                    'type' => 'string',
+                                ],
+                                'TagValue' => [
+                                    'type' => 'string',
+                                ],
+                            ],
+                            'type' => 'object',
+                        ],
+                        'maxItems' => 5,
+                        'required' => false,
+                        'type' => 'array',
+                    ],
+                    'style' => 'repeatList',
+                ],
+            ],
+            'responses' => [
+                200 => [
+                    'schema' => [
+                        'properties' => [
+                            'RequestId' => [
+                                'type' => 'string',
+                            ],
+                        ],
+                        'type' => 'object',
+                    ],
+                ],
+            ],
+            'schemes' => [
+                'http',
+                'https',
+            ],
+            'security' => [
+                [
+                    'AK' => [],
+                ],
+            ],
+        ],
+        'InsertTags' => [
+            'deprecated' => false,
+            'methods' => [
+                'post',
+            ],
+            'operationType' => 'readAndWrite',
+            'parameters' => [
+                [
+                    'in' => 'query',
+                    'name' => 'InstanceName',
+                    'schema' => [
+                        'required' => true,
+                        'type' => 'string',
+                    ],
+                ],
+                [
+                    'in' => 'query',
+                    'name' => 'TagInfo',
+                    'schema' => [
+                        'items' => [
+                            'properties' => [
+                                'TagKey' => [
+                                    'type' => 'string',
+                                ],
+                                'TagValue' => [
+                                    'type' => 'string',
+                                ],
+                            ],
+                            'type' => 'object',
+                        ],
+                        'maxItems' => 5,
+                        'required' => false,
+                        'type' => 'array',
+                    ],
+                    'style' => 'repeatList',
+                ],
+            ],
+            'responses' => [
+                200 => [
+                    'schema' => [
+                        'properties' => [
+                            'RequestId' => [
+                                'type' => 'string',
+                            ],
+                        ],
+                        'type' => 'object',
+                    ],
+                ],
+            ],
+            'schemes' => [
+                'http',
+                'https',
+            ],
+            'security' => [
+                [
+                    'AK' => [],
+                ],
+            ],
+        ],
+        'ListClusterType' => [
+            'deprecated' => false,
+            'methods' => [
+                'get',
+            ],
+            'operationType' => 'readAndWrite',
+            'parameters' => [],
+            'responses' => [
+                200 => [
+                    'schema' => [
+                        'properties' => [
+                            'ClusterTypeDetailList' => [
+                                'items' => [
+                                    'properties' => [
+                                        'ClusterType' => [
+                                            'type' => 'string',
+                                        ],
+                                        'IsMultiAZ' => [
+                                            'type' => 'boolean',
+                                        ],
+                                    ],
+                                    'type' => 'object',
+                                ],
+                                'type' => 'array',
+                            ],
+                            'ClusterTypeInfos' => [
+                                'items' => [
+                                    'type' => 'string',
+                                ],
+                                'type' => 'array',
+                            ],
+                            'RequestId' => [
+                                'type' => 'string',
+                            ],
+                        ],
+                        'type' => 'object',
+                    ],
+                ],
+            ],
+            'schemes' => [
+                'http',
+                'https',
+            ],
+            'security' => [
+                [
+                    'AK' => [],
+                ],
+            ],
+        ],
+        'ListInstance' => [
+            'deprecated' => false,
+            'methods' => [
+                'get',
+            ],
+            'operationType' => 'read',
+            'parameters' => [
+                [
+                    'in' => 'query',
+                    'name' => 'PageNum',
+                    'schema' => [
+                        'format' => 'int64',
+                        'required' => false,
+                        'type' => 'integer',
+                    ],
+                ],
+                [
+                    'in' => 'query',
+                    'name' => 'PageSize',
+                    'schema' => [
+                        'format' => 'int64',
+                        'required' => false,
+                        'type' => 'integer',
+                    ],
+                ],
+                [
+                    'in' => 'query',
+                    'name' => 'TagInfo',
+                    'schema' => [
+                        'items' => [
+                            'properties' => [
+                                'TagKey' => [
+                                    'type' => 'string',
+                                ],
+                                'TagValue' => [
+                                    'type' => 'string',
+                                ],
+                            ],
+                            'type' => 'object',
+                        ],
+                        'maxItems' => 5,
+                        'required' => false,
+                        'type' => 'array',
+                    ],
+                    'style' => 'repeatList',
+                ],
+            ],
+            'responses' => [
+                200 => [
+                    'schema' => [
+                        'properties' => [
+                            'InstanceInfos' => [
+                                'items' => [
+                                    'properties' => [
+                                        'InstanceName' => [
+                                            'type' => 'string',
+                                        ],
+                                        'Timestamp' => [
+                                            'type' => 'string',
+                                        ],
+                                    ],
+                                    'type' => 'object',
+                                ],
+                                'type' => 'array',
+                            ],
+                            'PageNum' => [
+                                'format' => 'int64',
+                                'type' => 'integer',
+                            ],
+                            'PageSize' => [
+                                'format' => 'int64',
+                                'type' => 'integer',
+                            ],
+                            'RequestId' => [
+                                'type' => 'string',
+                            ],
+                            'TotalCount' => [
+                                'format' => 'int64',
+                                'type' => 'integer',
+                            ],
+                        ],
+                        'type' => 'object',
+                    ],
+                ],
+            ],
+            'schemes' => [
+                'http',
+                'https',
+            ],
+            'security' => [
+                [
+                    'AK' => [],
+                ],
+            ],
+        ],
+        'ListTags' => [
+            'deprecated' => false,
+            'methods' => [
+                'post',
+            ],
+            'operationType' => 'read',
+            'parameters' => [
+                [
+                    'in' => 'query',
+                    'name' => 'InstanceName',
+                    'schema' => [
+                        'required' => false,
+                        'type' => 'string',
+                    ],
+                ],
+                [
+                    'in' => 'query',
+                    'name' => 'PageNum',
+                    'schema' => [
+                        'format' => 'int64',
+                        'required' => false,
+                        'type' => 'integer',
+                    ],
+                ],
+                [
+                    'in' => 'query',
+                    'name' => 'PageSize',
+                    'schema' => [
+                        'format' => 'int64',
+                        'required' => false,
+                        'type' => 'integer',
+                    ],
+                ],
+                [
+                    'in' => 'query',
+                    'name' => 'TagInfo',
+                    'schema' => [
+                        'items' => [
+                            'properties' => [
+                                'TagKey' => [
+                                    'type' => 'string',
+                                ],
+                                'TagValue' => [
+                                    'type' => 'string',
+                                ],
+                            ],
+                            'type' => 'object',
+                        ],
+                        'maxItems' => 5,
+                        'required' => false,
+                        'type' => 'array',
+                    ],
+                    'style' => 'repeatList',
+                ],
+            ],
+            'responses' => [
+                200 => [
+                    'schema' => [
+                        'properties' => [
+                            'PageNum' => [
+                                'format' => 'int64',
+                                'type' => 'integer',
+                            ],
+                            'PageSize' => [
+                                'format' => 'int64',
+                                'type' => 'integer',
+                            ],
+                            'RequestId' => [
+                                'type' => 'string',
+                            ],
+                            'TagInfos' => [
+                                'items' => [
+                                    'properties' => [
+                                        'TagKey' => [
+                                            'type' => 'string',
+                                        ],
+                                        'TagValue' => [
+                                            'type' => 'string',
+                                        ],
+                                    ],
+                                    'type' => 'object',
+                                ],
+                                'type' => 'array',
+                            ],
+                            'TotalCount' => [
+                                'format' => 'int64',
+                                'type' => 'integer',
+                            ],
+                        ],
+                        'type' => 'object',
+                    ],
+                ],
+            ],
+            'schemes' => [
+                'http',
+                'https',
+            ],
+            'security' => [
+                [
+                    'AK' => [],
+                ],
+            ],
+        ],
+        'ListVpcInfoByInstance' => [
+            'deprecated' => false,
+            'methods' => [
+                'get',
+            ],
+            'operationType' => 'read',
+            'parameters' => [
+                [
+                    'in' => 'query',
+                    'name' => 'InstanceName',
+                    'schema' => [
+                        'required' => true,
+                        'type' => 'string',
+                    ],
+                ],
+                [
+                    'in' => 'query',
+                    'name' => 'PageNum',
+                    'schema' => [
+                        'format' => 'int64',
+                        'required' => false,
+                        'type' => 'integer',
+                    ],
+                ],
+                [
+                    'in' => 'query',
+                    'name' => 'PageSize',
+                    'schema' => [
+                        'format' => 'int64',
+                        'required' => false,
+                        'type' => 'integer',
+                    ],
+                ],
+            ],
+            'responses' => [
+                200 => [
+                    'schema' => [
+                        'properties' => [
+                            'InstanceName' => [
+                                'type' => 'string',
+                            ],
+                            'PageNum' => [
+                                'format' => 'int64',
+                                'type' => 'integer',
+                            ],
+                            'PageSize' => [
+                                'format' => 'int64',
+                                'type' => 'integer',
+                            ],
+                            'RequestId' => [
+                                'type' => 'string',
+                            ],
+                            'TotalCount' => [
+                                'format' => 'int64',
+                                'type' => 'integer',
+                            ],
+                            'VpcInfos' => [
+                                'items' => [
+                                    'properties' => [
+                                        'Domain' => [
+                                            'type' => 'string',
+                                        ],
+                                        'Endpoint' => [
+                                            'type' => 'string',
+                                        ],
+                                        'InstanceVpcName' => [
+                                            'type' => 'string',
+                                        ],
+                                        'RegionNo' => [
+                                            'type' => 'string',
+                                        ],
+                                        'VpcId' => [
+                                            'type' => 'string',
+                                        ],
+                                    ],
+                                    'type' => 'object',
+                                ],
+                                'type' => 'array',
+                            ],
+                        ],
+                        'type' => 'object',
+                    ],
+                ],
+            ],
+            'schemes' => [
+                'http',
+                'https',
+            ],
+            'security' => [
+                [
+                    'AK' => [],
+                ],
+            ],
+        ],
+        'ListVpcInfoByVpc' => [
+            'deprecated' => false,
+            'methods' => [
+                'get',
+            ],
+            'operationType' => 'readAndWrite',
+            'parameters' => [
+                [
+                    'in' => 'query',
+                    'name' => 'VpcId',
+                    'schema' => [
+                        'required' => true,
+                        'type' => 'string',
+                    ],
+                ],
+                [
+                    'in' => 'query',
+                    'name' => 'PageNum',
+                    'schema' => [
+                        'format' => 'int64',
+                        'required' => false,
+                        'type' => 'integer',
+                    ],
+                ],
+                [
+                    'in' => 'query',
+                    'name' => 'PageSize',
+                    'schema' => [
+                        'format' => 'int64',
+                        'required' => false,
+                        'type' => 'integer',
+                    ],
+                ],
+                [
+                    'in' => 'query',
+                    'name' => 'TagInfo',
+                    'schema' => [
+                        'items' => [
+                            'properties' => [
+                                'TagKey' => [
+                                    'type' => 'string',
+                                ],
+                                'TagValue' => [
+                                    'type' => 'string',
+                                ],
+                            ],
+                            'type' => 'object',
+                        ],
+                        'maxItems' => 5,
+                        'required' => false,
+                        'type' => 'array',
+                    ],
+                    'style' => 'repeatList',
+                ],
+            ],
+            'responses' => [
+                200 => [
+                    'schema' => [
+                        'properties' => [
+                            'PageNum' => [
+                                'format' => 'int64',
+                                'type' => 'integer',
+                            ],
+                            'PageSize' => [
+                                'format' => 'int64',
+                                'type' => 'integer',
+                            ],
+                            'RequestId' => [
+                                'type' => 'string',
+                            ],
+                            'TotalCount' => [
+                                'format' => 'int64',
+                                'type' => 'integer',
+                            ],
+                            'VpcId' => [
+                                'type' => 'string',
+                            ],
+                            'VpcInfos' => [
+                                'items' => [
+                                    'properties' => [
+                                        'Domain' => [
+                                            'type' => 'string',
+                                        ],
+                                        'Endpoint' => [
+                                            'type' => 'string',
+                                        ],
+                                        'InstanceName' => [
+                                            'type' => 'string',
+                                        ],
+                                        'InstanceVpcName' => [
+                                            'type' => 'string',
+                                        ],
+                                        'RegionNo' => [
+                                            'type' => 'string',
+                                        ],
+                                    ],
+                                    'type' => 'object',
+                                ],
+                                'type' => 'array',
+                            ],
+                        ],
+                        'type' => 'object',
+                    ],
+                ],
+            ],
+            'schemes' => [
+                'http',
+                'https',
+            ],
+            'security' => [
+                [
+                    'AK' => [],
+                ],
+            ],
+        ],
+        'OpenOtsService' => [
+            'deprecated' => false,
+            'errorCodes' => [
+                400 => [
+                    [
+                        'errorCode' => 'BASIC_INFO_UNCOMPLETED',
+                        'errorMessage' => '基本信息待完善，完善基本信息后才能进行该操作。',
+                    ],
+                    [
+                        'errorCode' => 'SALE_VALIDATE_NO_SPECIFIC_CODE_FAILED',
+                        'errorMessage' => '您有欠费账单，不符合购买条件。请先充值结清账单后再购买。',
+                    ],
+                    [
+                        'errorCode' => 'ORDER.OPEND',
+                        'errorMessage' => '已开通',
+                    ],
+                ],
+            ],
+            'methods' => [
+                'post',
+                'get',
+            ],
+            'operationType' => 'readAndWrite',
+            'parameters' => [],
+            'responses' => [
+                200 => [
+                    'schema' => [
+                        'properties' => [
+                            'OrderId' => [
+                                'type' => 'string',
+                            ],
+                            'RequestId' => [
+                                'type' => 'string',
+                            ],
+                        ],
+                        'type' => 'object',
+                    ],
+                ],
+            ],
+            'schemes' => [
+                'http',
+                'https',
+            ],
+            'security' => [
+                [
+                    'AK' => [],
+                ],
+                [
+                    'APP' => [],
+                ],
+                [
+                    'PrivateKey' => [],
+                ],
+                [
+                    'BearerToken' => [],
+                ],
+            ],
+        ],
+        'UnbindInstance2Vpc' => [
+            'deprecated' => false,
+            'methods' => [
+                'post',
+            ],
+            'operationType' => 'readAndWrite',
+            'parameters' => [
+                [
+                    'in' => 'query',
+                    'name' => 'InstanceName',
+                    'schema' => [
+                        'required' => true,
+                        'type' => 'string',
+                    ],
+                ],
+                [
+                    'in' => 'query',
+                    'name' => 'InstanceVpcName',
+                    'schema' => [
+                        'required' => true,
+                        'type' => 'string',
+                    ],
+                ],
+                [
+                    'in' => 'query',
+                    'name' => 'RegionNo',
+                    'schema' => [
+                        'required' => false,
+                        'type' => 'string',
+                    ],
+                ],
+            ],
+            'responses' => [
+                200 => [
+                    'schema' => [
+                        'properties' => [
+                            'RequestId' => [
+                                'type' => 'string',
+                            ],
+                        ],
+                        'type' => 'object',
+                    ],
+                ],
+            ],
+            'schemes' => [
+                'http',
+                'https',
+            ],
+            'security' => [
+                [
+                    'AK' => [],
+                ],
+            ],
+        ],
+        'UpdateInstance' => [
+            'deprecated' => false,
+            'methods' => [
+                'post',
+            ],
+            'operationType' => 'readAndWrite',
+            'parameters' => [
+                [
+                    'in' => 'query',
+                    'name' => 'InstanceName',
+                    'schema' => [
+                        'required' => true,
+                        'type' => 'string',
+                    ],
+                ],
+                [
+                    'in' => 'query',
+                    'name' => 'Network',
+                    'schema' => [
+                        'required' => false,
+                        'type' => 'string',
+                    ],
+                ],
+            ],
+            'responses' => [
+                200 => [
+                    'schema' => [
+                        'properties' => [
+                            'RequestId' => [
+                                'type' => 'string',
+                            ],
+                        ],
+                        'type' => 'object',
+                    ],
+                ],
+            ],
+            'schemes' => [
+                'http',
+                'https',
+            ],
+            'security' => [
+                [
+                    'AK' => [],
+                ],
+            ],
+        ],
+    ],
+    'endpoints' => [],
+];

--- a/data/tablestore/2020-12-09/api-docs.php
+++ b/data/tablestore/2020-12-09/api-docs.php
@@ -1,0 +1,932 @@
+<?php return [
+    'version' => '1.0',
+    'info' => [
+        'style' => 'ROA',
+        'product' => 'Tablestore',
+        'version' => '2020-12-09',
+    ],
+    'directories' => [],
+    'components' => [
+        'schema' => [],
+    ],
+    'apis' => [
+        'ChangeResourceGroup' => [
+            'consumes' => [
+                'application/json',
+            ],
+            'deprecated' => false,
+            'methods' => [
+                'post',
+            ],
+            'parameters' => [
+                [
+                    'in' => 'body',
+                    'name' => 'body',
+                    'schema' => [
+                        'properties' => [
+                            'NewResourceGroupId' => [
+                                'required' => true,
+                                'title' => 'new resource group id',
+                                'type' => 'string',
+                            ],
+                            'ResourceId' => [
+                                'required' => true,
+                                'title' => 'resource id, aka ots instance name',
+                                'type' => 'string',
+                            ],
+                        ],
+                        'title' => 'A short description of struct',
+                        'type' => 'object',
+                    ],
+                    'style' => 'json',
+                ],
+            ],
+            'path' => '/v2/openapi/changeresourcegroup',
+            'produces' => [
+                'application/json',
+            ],
+            'responses' => [
+                200 => [
+                    'schema' => [
+                        'properties' => [
+                            'RequestId' => [
+                                'title' => 'Id of the request',
+                                'type' => 'string',
+                            ],
+                        ],
+                        'title' => 'Schema of Response',
+                        'type' => 'object',
+                    ],
+                ],
+            ],
+            'schemes' => [
+                'http',
+                'https',
+            ],
+            'security' => [
+                [
+                    'AK' => [],
+                ],
+            ],
+            'summary' => '变更资源组',
+        ],
+        'CreateInstance' => [
+            'consumes' => [
+                'application/json',
+            ],
+            'deprecated' => false,
+            'methods' => [
+                'post',
+            ],
+            'operationType' => 'write',
+            'parameters' => [
+                [
+                    'in' => 'body',
+                    'name' => 'body',
+                    'schema' => [
+                        'properties' => [
+                            'ClusterType' => [
+                                'example' => 'SSD vs HYBRID',
+                                'required' => true,
+                                'title' => 'cluster type',
+                                'type' => 'string',
+                            ],
+                            'DisableReplication' => [
+                                'title' => '是否开启实例的容灾状态',
+                                'type' => 'boolean',
+                            ],
+                            'InstanceDescription' => [
+                                'example' => '实例描述',
+                                'title' => 'instance description',
+                                'type' => 'string',
+                            ],
+                            'InstanceName' => [
+                                'example' => 'first-ins',
+                                'required' => true,
+                                'title' => 'instance name',
+                                'type' => 'string',
+                            ],
+                            'Network' => [
+                                'required' => false,
+                                'title' => '（已弃用）实例网络类型。NORMAL, VPC_CONSOLE。默认为NORMAL。',
+                                'type' => 'string',
+                            ],
+                            'NetworkSourceACL' => [
+                                'items' => [
+                                    'type' => 'string',
+                                ],
+                                'required' => false,
+                                'title' => '实例允许的网络来源列表。默认都允许。TRUST_PROXY: 控制台。',
+                                'type' => 'array',
+                            ],
+                            'NetworkTypeACL' => [
+                                'items' => [
+                                    'type' => 'string',
+                                ],
+                                'required' => false,
+                                'title' => '实例允许的网络类型列表。默认都允许。CLASSIC: 经典网；INTERNET: 公网；VPC：VPC网络。',
+                                'type' => 'array',
+                            ],
+                            'Policy' => [
+                                'maxLength' => 4000,
+                                'title' => '实例访问控制策略，JSON格式。配置语法见：https://help.aliyun.com/zh/ram/user-guide/policy-structure-and-syntax',
+                                'type' => 'string',
+                            ],
+                            'ResourceGroupId' => [
+                                'example' => 'rg-acfmxh4em5jnbcd',
+                                'title' => 'resource group id',
+                                'type' => 'string',
+                            ],
+                            'Tags' => [
+                                'items' => [
+                                    'properties' => [
+                                        'Key' => [
+                                            'required' => true,
+                                            'type' => 'string',
+                                        ],
+                                        'Value' => [
+                                            'required' => true,
+                                            'type' => 'string',
+                                        ],
+                                    ],
+                                    'type' => 'object',
+                                ],
+                                'title' => 'tag',
+                                'type' => 'array',
+                            ],
+                        ],
+                        'required' => false,
+                        'title' => 'request body',
+                        'type' => 'object',
+                    ],
+                    'style' => 'json',
+                ],
+            ],
+            'path' => '/v2/openapi/createinstance',
+            'produces' => [
+                'application/json',
+            ],
+            'responses' => [
+                200 => [
+                    'schema' => [
+                        'properties' => [
+                            'Code' => [
+                                'title' => '响应状态码',
+                                'type' => 'string',
+                            ],
+                            'Message' => [
+                                'title' => '响应消息描述',
+                                'type' => 'string',
+                            ],
+                            'RequestId' => [
+                                'title' => 'request id',
+                                'type' => 'string',
+                            ],
+                        ],
+                        'title' => 'Schema of Response',
+                        'type' => 'object',
+                    ],
+                ],
+            ],
+            'schemes' => [
+                'http',
+                'https',
+            ],
+            'security' => [
+                [
+                    'AK' => [],
+                ],
+            ],
+            'summary' => '创建实例',
+        ],
+        'DeleteInstance' => [
+            'consumes' => [
+                'application/json',
+            ],
+            'deprecated' => false,
+            'methods' => [
+                'post',
+            ],
+            'operationType' => 'write',
+            'parameters' => [
+                [
+                    'in' => 'body',
+                    'name' => 'body',
+                    'schema' => [
+                        'properties' => [
+                            'InstanceName' => [
+                                'required' => true,
+                                'title' => 'instance name',
+                                'type' => 'string',
+                            ],
+                        ],
+                        'required' => false,
+                        'title' => 'request body',
+                        'type' => 'object',
+                    ],
+                    'style' => 'json',
+                ],
+            ],
+            'path' => '/v2/openapi/deleteinstance',
+            'produces' => [
+                'application/json',
+            ],
+            'responses' => [
+                200 => [
+                    'schema' => [
+                        'properties' => [
+                            'RequestId' => [
+                                'title' => 'Id of the request',
+                                'type' => 'string',
+                            ],
+                        ],
+                        'title' => 'Schema of Response',
+                        'type' => 'object',
+                    ],
+                ],
+            ],
+            'schemes' => [
+                'http',
+                'https',
+            ],
+            'security' => [
+                [
+                    'AK' => [],
+                ],
+            ],
+            'summary' => '删除实例',
+        ],
+        'DescribeRegions' => [
+            'deprecated' => false,
+            'methods' => [
+                'get',
+            ],
+            'parameters' => [],
+            'path' => '/region/DescribeRegions',
+            'responses' => [
+                200 => [
+                    'schema' => [
+                        'properties' => [
+                            'Regions' => [
+                                'items' => [
+                                    'properties' => [
+                                        'I18nKey' => [
+                                            'title' => 'region key',
+                                            'type' => 'string',
+                                        ],
+                                        'RegionId' => [
+                                            'title' => 'region id',
+                                            'type' => 'string',
+                                        ],
+                                    ],
+                                    'type' => 'object',
+                                ],
+                                'title' => 'region list',
+                                'type' => 'array',
+                            ],
+                            'requestId' => [
+                                'title' => 'Id of the request',
+                                'type' => 'string',
+                            ],
+                        ],
+                        'title' => 'Schema of Response',
+                        'type' => 'object',
+                    ],
+                ],
+            ],
+            'schemes' => [
+                'http',
+                'https',
+            ],
+            'security' => [
+                [
+                    'AK' => [],
+                ],
+            ],
+            'summary' => '获取用户可见region列表',
+        ],
+        'GetInstance' => [
+            'deprecated' => false,
+            'methods' => [
+                'get',
+            ],
+            'operationType' => 'read',
+            'parameters' => [
+                [
+                    'in' => 'query',
+                    'name' => 'InstanceName',
+                    'schema' => [
+                        'required' => true,
+                        'type' => 'string',
+                    ],
+                ],
+            ],
+            'path' => '/v2/openapi/getinstance',
+            'produces' => [
+                'application/json',
+            ],
+            'responses' => [
+                200 => [
+                    'schema' => [
+                        'properties' => [
+                            'AliasName' => [
+                                'type' => 'string',
+                            ],
+                            'CreateTime' => [
+                                'type' => 'string',
+                            ],
+                            'InstanceDescription' => [
+                                'type' => 'string',
+                            ],
+                            'InstanceName' => [
+                                'type' => 'string',
+                            ],
+                            'InstanceSpecification' => [
+                                'type' => 'string',
+                            ],
+                            'InstanceStatus' => [
+                                'type' => 'string',
+                            ],
+                            'Network' => [
+                                'type' => 'string',
+                            ],
+                            'NetworkSourceACL' => [
+                                'items' => [
+                                    'type' => 'string',
+                                ],
+                                'title' => '实例允许的网络来源列表。TRUST_PROXY: 控制台；',
+                                'type' => 'array',
+                            ],
+                            'NetworkTypeACL' => [
+                                'items' => [
+                                    'type' => 'string',
+                                ],
+                                'title' => '实例允许的网络类型列表。CLASSIC: 经典网；INTERNET: 公网；VPC：VPC网络。',
+                                'type' => 'array',
+                            ],
+                            'PaymentType' => [
+                                'type' => 'string',
+                            ],
+                            'Policy' => [
+                                'title' => 'Instance policy 访问控制策略',
+                                'type' => 'string',
+                            ],
+                            'PolicyVersion' => [
+                                'format' => 'int64',
+                                'title' => 'Instance policy的版本',
+                                'type' => 'integer',
+                            ],
+                            'RegionId' => [
+                                'type' => 'string',
+                            ],
+                            'RequestId' => [
+                                'title' => 'Id of the request',
+                                'type' => 'string',
+                            ],
+                            'ResourceGroupId' => [
+                                'example' => 'rg-acfmxh4em5jncda',
+                                'title' => '资源组id',
+                                'type' => 'string',
+                            ],
+                            'SPInstanceId' => [
+                                'type' => 'string',
+                            ],
+                            'StorageType' => [
+                                'type' => 'string',
+                            ],
+                            'TableQuota' => [
+                                'format' => 'int32',
+                                'type' => 'integer',
+                            ],
+                            'Tags' => [
+                                'items' => [
+                                    'properties' => [
+                                        'Key' => [
+                                            'type' => 'string',
+                                        ],
+                                        'TagKey' => [
+                                            'type' => 'string',
+                                        ],
+                                        'TagValue' => [
+                                            'type' => 'string',
+                                        ],
+                                        'Value' => [
+                                            'type' => 'string',
+                                        ],
+                                    ],
+                                    'type' => 'object',
+                                ],
+                                'type' => 'array',
+                            ],
+                            'UserId' => [
+                                'type' => 'string',
+                            ],
+                            'VCUQuota' => [
+                                'format' => 'int32',
+                                'type' => 'integer',
+                            ],
+                        ],
+                        'title' => 'Schema of Response',
+                        'type' => 'object',
+                    ],
+                ],
+            ],
+            'schemes' => [
+                'http',
+                'https',
+            ],
+            'security' => [
+                [
+                    'AK' => [],
+                ],
+            ],
+            'summary' => '获取实例',
+        ],
+        'ListInstances' => [
+            'deprecated' => false,
+            'methods' => [
+                'get',
+            ],
+            'operationType' => 'read',
+            'parameters' => [
+                [
+                    'in' => 'query',
+                    'name' => 'Status',
+                    'schema' => [
+                        'type' => 'string',
+                    ],
+                ],
+                [
+                    'in' => 'query',
+                    'name' => 'MaxResults',
+                    'schema' => [
+                        'format' => 'int32',
+                        'type' => 'integer',
+                    ],
+                ],
+                [
+                    'in' => 'query',
+                    'name' => 'NextToken',
+                    'schema' => [
+                        'type' => 'string',
+                    ],
+                ],
+                [
+                    'in' => 'query',
+                    'name' => 'InstanceName',
+                    'schema' => [
+                        'type' => 'string',
+                    ],
+                ],
+                [
+                    'in' => 'query',
+                    'name' => 'ResourceGroupId',
+                    'schema' => [
+                        'type' => 'string',
+                    ],
+                ],
+                [
+                    'in' => 'query',
+                    'name' => 'InstanceNameList',
+                    'schema' => [
+                        'items' => [
+                            'type' => 'string',
+                        ],
+                        'type' => 'array',
+                    ],
+                    'style' => 'simple',
+                ],
+            ],
+            'path' => '/v2/openapi/listinstances',
+            'produces' => [
+                'application/json',
+            ],
+            'responses' => [
+                200 => [
+                    'schema' => [
+                        'properties' => [
+                            'Instances' => [
+                                'items' => [
+                                    'properties' => [
+                                        'AliasName' => [
+                                            'type' => 'string',
+                                        ],
+                                        'CreateTime' => [
+                                            'type' => 'string',
+                                        ],
+                                        'InstanceDescription' => [
+                                            'type' => 'string',
+                                        ],
+                                        'InstanceName' => [
+                                            'title' => '实例名称，唯一键',
+                                            'type' => 'string',
+                                        ],
+                                        'InstanceSpecification' => [
+                                            'type' => 'string',
+                                        ],
+                                        'InstanceStatus' => [
+                                            'type' => 'string',
+                                        ],
+                                        'PaymentType' => [
+                                            'type' => 'string',
+                                        ],
+                                        'RegionId' => [
+                                            'type' => 'string',
+                                        ],
+                                        'ResourceGroupId' => [
+                                            'example' => 'rg-acfmxh4em5jnbcd',
+                                            'title' => '资源组id',
+                                            'type' => 'string',
+                                        ],
+                                        'SPInstanceId' => [
+                                            'type' => 'string',
+                                        ],
+                                        'StorageType' => [
+                                            'type' => 'string',
+                                        ],
+                                        'UserId' => [
+                                            'type' => 'string',
+                                        ],
+                                        'VCUQuota' => [
+                                            'format' => 'int32',
+                                            'type' => 'integer',
+                                        ],
+                                    ],
+                                    'type' => 'object',
+                                ],
+                                'type' => 'array',
+                            ],
+                            'NextToken' => [
+                                'type' => 'string',
+                            ],
+                            'RequestId' => [
+                                'title' => 'Id of the request',
+                                'type' => 'string',
+                            ],
+                            'TotalCount' => [
+                                'format' => 'int64',
+                                'type' => 'integer',
+                            ],
+                        ],
+                        'title' => 'Schema of Response',
+                        'type' => 'object',
+                    ],
+                ],
+            ],
+            'schemes' => [
+                'http',
+                'https',
+            ],
+            'security' => [
+                [
+                    'AK' => [],
+                ],
+            ],
+            'summary' => '列取实例',
+        ],
+        'ListTagResources' => [
+            'deprecated' => false,
+            'methods' => [
+                'get',
+            ],
+            'parameters' => [
+                [
+                    'in' => 'query',
+                    'name' => 'MaxResults',
+                    'schema' => [
+                        'format' => 'int32',
+                        'type' => 'integer',
+                    ],
+                ],
+                [
+                    'in' => 'query',
+                    'name' => 'ResourceType',
+                    'schema' => [
+                        'type' => 'string',
+                    ],
+                ],
+                [
+                    'in' => 'query',
+                    'name' => 'ResourceIds',
+                    'schema' => [
+                        'items' => [
+                            'type' => 'string',
+                        ],
+                        'type' => 'array',
+                    ],
+                    'style' => 'simple',
+                ],
+                [
+                    'in' => 'query',
+                    'name' => 'Tags',
+                    'schema' => [
+                        'items' => [
+                            'properties' => [
+                                'Key' => [
+                                    'type' => 'string',
+                                ],
+                                'Value' => [
+                                    'type' => 'string',
+                                ],
+                            ],
+                            'type' => 'object',
+                        ],
+                        'type' => 'array',
+                    ],
+                    'style' => 'json',
+                ],
+                [
+                    'in' => 'query',
+                    'name' => 'NextToken',
+                    'schema' => [
+                        'type' => 'string',
+                    ],
+                ],
+            ],
+            'path' => '/v2/openapi/listtagresources',
+            'responses' => [
+                200 => [
+                    'schema' => [
+                        'properties' => [
+                            'MaxResults' => [
+                                'format' => 'int32',
+                                'type' => 'integer',
+                            ],
+                            'NextToken' => [
+                                'type' => 'string',
+                            ],
+                            'TagResources' => [
+                                'items' => [
+                                    'properties' => [
+                                        'ResourceId' => [
+                                            'title' => '资源ID（名称）。',
+                                            'type' => 'string',
+                                        ],
+                                        'ResourceType' => [
+                                            'title' => '资源类型。如ALIYUN::OTS::INSTANCE, ALIYUN::VPC::VPC。',
+                                            'type' => 'string',
+                                        ],
+                                        'TagKey' => [
+                                            'title' => '标签键。',
+                                            'type' => 'string',
+                                        ],
+                                        'TagValue' => [
+                                            'title' => '标签值。',
+                                            'type' => 'string',
+                                        ],
+                                    ],
+                                    'title' => '标签对象。',
+                                    'type' => 'object',
+                                ],
+                                'title' => '标签列表。',
+                                'type' => 'array',
+                            ],
+                            'requestId' => [
+                                'title' => 'Id of the request',
+                                'type' => 'string',
+                            ],
+                        ],
+                        'title' => 'Schema of Response',
+                        'type' => 'object',
+                    ],
+                ],
+            ],
+            'schemes' => [
+                'http',
+                'https',
+            ],
+            'security' => [
+                [
+                    'AK' => [],
+                ],
+            ],
+            'summary' => '获取标签资源列表',
+        ],
+        'TagResources' => [
+            'consumes' => [
+                'application/json',
+            ],
+            'deprecated' => false,
+            'methods' => [
+                'post',
+            ],
+            'operationType' => 'write',
+            'parameters' => [
+                [
+                    'in' => 'body',
+                    'name' => 'body',
+                    'schema' => [
+                        'properties' => [
+                            'ResourceIds' => [
+                                'items' => [
+                                    'required' => true,
+                                    'type' => 'string',
+                                ],
+                                'required' => true,
+                                'title' => 'resource ids',
+                                'type' => 'array',
+                            ],
+                            'ResourceType' => [
+                                'required' => true,
+                                'title' => 'resource type',
+                                'type' => 'string',
+                            ],
+                            'Tags' => [
+                                'items' => [
+                                    'properties' => [
+                                        'Key' => [
+                                            'required' => true,
+                                            'title' => 'tag key',
+                                            'type' => 'string',
+                                        ],
+                                        'Value' => [
+                                            'required' => true,
+                                            'title' => 'tag value',
+                                            'type' => 'string',
+                                        ],
+                                    ],
+                                    'required' => true,
+                                    'type' => 'object',
+                                ],
+                                'required' => true,
+                                'title' => 'tags',
+                                'type' => 'array',
+                            ],
+                        ],
+                        'title' => 'A short description of struct',
+                        'type' => 'object',
+                    ],
+                    'style' => 'json',
+                ],
+            ],
+            'path' => '/v2/openapi/tagresources',
+            'produces' => [
+                'application/json',
+            ],
+            'responses' => [
+                200 => [
+                    'schema' => [
+                        'properties' => [
+                            'RequestId' => [
+                                'title' => 'Id of the request',
+                                'type' => 'string',
+                            ],
+                        ],
+                        'title' => 'Schema of Response',
+                        'type' => 'object',
+                    ],
+                ],
+            ],
+            'schemes' => [
+                'http',
+                'https',
+            ],
+            'security' => [
+                [
+                    'AK' => [],
+                ],
+            ],
+            'summary' => '打资源标签',
+        ],
+        'UntagResources' => [
+            'deprecated' => false,
+            'methods' => [
+                'post',
+            ],
+            'parameters' => [
+                [
+                    'in' => 'body',
+                    'name' => 'body',
+                    'schema' => [
+                        'properties' => [
+                            'All' => [
+                                'type' => 'boolean',
+                            ],
+                            'ResourceIds' => [
+                                'items' => [
+                                    'type' => 'string',
+                                ],
+                                'type' => 'array',
+                            ],
+                            'ResourceType' => [
+                                'type' => 'string',
+                            ],
+                            'TagKeys' => [
+                                'items' => [
+                                    'type' => 'string',
+                                ],
+                                'type' => 'array',
+                            ],
+                        ],
+                        'type' => 'object',
+                    ],
+                    'style' => 'json',
+                ],
+            ],
+            'path' => '/v2/openapi/untagresources',
+            'responses' => [
+                200 => [
+                    'schema' => [
+                        'properties' => [
+                            'requestId' => [
+                                'title' => 'Id of the request',
+                                'type' => 'string',
+                            ],
+                        ],
+                        'title' => 'Schema of Response',
+                        'type' => 'object',
+                    ],
+                ],
+            ],
+            'schemes' => [
+                'http',
+                'https',
+            ],
+            'security' => [
+                [
+                    'AK' => [],
+                ],
+            ],
+            'summary' => '删除资源标签',
+        ],
+        'UpdateInstance' => [
+            'consumes' => [
+                'application/json',
+            ],
+            'deprecated' => false,
+            'methods' => [
+                'post',
+            ],
+            'operationType' => 'write',
+            'parameters' => [
+                [
+                    'in' => 'body',
+                    'name' => 'body',
+                    'schema' => [
+                        'properties' => [
+                            'AliasName' => [
+                                'type' => 'string',
+                            ],
+                            'InstanceDescription' => [
+                                'type' => 'string',
+                            ],
+                            'InstanceName' => [
+                                'required' => true,
+                                'type' => 'string',
+                            ],
+                            'Network' => [
+                                'title' => '（已弃用）实例网络类型。NORMAL, VPC_CONSOLE。默认为NORMAL。',
+                                'type' => 'string',
+                            ],
+                            'NetworkSourceACL' => [
+                                'items' => [
+                                    'type' => 'string',
+                                ],
+                                'title' => '更新实例允许的网络来源列表，默认都允许。必须与TRUST_PROXY: 控制台；',
+                                'type' => 'array',
+                            ],
+                            'NetworkTypeACL' => [
+                                'items' => [
+                                    'title' => '',
+                                    'type' => 'string',
+                                ],
+                                'required' => false,
+                                'title' => '更新实例允许的网络类型列表。默认都允许。CLASSIC: 经典网；INTERNET: 公网；VPC：VPC网络。',
+                                'type' => 'array',
+                            ],
+                        ],
+                        'type' => 'object',
+                    ],
+                    'style' => 'json',
+                ],
+            ],
+            'path' => '/v2/openapi/updateinstance',
+            'produces' => [
+                'application/json',
+            ],
+            'responses' => [
+                200 => [
+                    'schema' => [
+                        'properties' => [
+                            'RequestId' => [
+                                'type' => 'string',
+                            ],
+                        ],
+                        'type' => 'object',
+                    ],
+                ],
+            ],
+            'schemes' => [
+                'http',
+                'https',
+            ],
+            'security' => [
+                [
+                    'AK' => [],
+                ],
+            ],
+            'summary' => '更新实例',
+        ],
+    ],
+    'endpoints' => [],
+];

--- a/src/AcsClient.php
+++ b/src/AcsClient.php
@@ -39,9 +39,9 @@ abstract class AcsClient
 {
     public const int MAJOR_VERSION = 0;
 
-    private ApiDocs $docs;
+    protected ApiDocs $docs;
 
-    private ?string $region = null;
+    protected string $region;
 
     protected string $endpoint;
 
@@ -66,16 +66,27 @@ abstract class AcsClient
     public function __construct(
         protected array $config
     ) {
-        $this->docs = ApiDocsResolver::make()
-            ->resolve(basename(str_replace('\\', '/', static::class)), $config);
+        $this->docs = $this->resolveApiDocs();
         $this->region = $config['region'];
-        $this->endpoint = $config['endpoint'] ?? $this->docs->getEndpoint($this->region);
+        $this->endpoint = $this->resolveEndpoint();
         $this->httpClient = $config['http_client'] ?? Psr18ClientDiscovery::find();
         $this->requestFactory = Psr17FactoryDiscovery::findRequestFactory();
         $this->streamFactory = Psr17FactoryDiscovery::findStreamFactory();
         $this->uriFactory = Psr17FactoryDiscovery::findUriFactory();
         $this->exceptionClass = $this->discoverExceptionClass();
         $this->resultProvider = new ResultProvider($this->docs, $this->exceptionClass);
+    }
+
+    protected function resolveApiDocs(): ApiDocs
+    {
+        $clientClass = basename(str_replace('\\', '/', static::class));
+
+        return ApiDocsResolver::make()->resolve($clientClass, $this->config);
+    }
+
+    protected function resolveEndpoint(): string
+    {
+        return $this->config['endpoint'] ?? $this->docs->getEndpoint($this->region);
     }
 
     /**

--- a/src/AcsClient.php
+++ b/src/AcsClient.php
@@ -77,6 +77,11 @@ abstract class AcsClient
         $this->resultProvider = new ResultProvider($this->docs, $this->exceptionClass);
     }
 
+    public function getEndpoint(): string
+    {
+        return $this->endpoint;
+    }
+
     protected function resolveApiDocs(): ApiDocs
     {
         $clientClass = basename(str_replace('\\', '/', static::class));

--- a/src/ApiDocsResolver.php
+++ b/src/ApiDocsResolver.php
@@ -86,7 +86,15 @@ final class ApiDocsResolver
 
             $products = require $filename;
 
+            if (! is_array($products)) {
+                throw new RuntimeException('The product data is invalid.');
+            }
+
             foreach ($products as $product) {
+                if (! isset($product['code']) || ! is_string($product['code'])) {
+                    throw new RuntimeException('Missing product code.');
+                }
+
                 $key = static::getNormalizedProductName($product['code']);
 
                 static::$products[$key] = $product;

--- a/src/Ots/OtsClient.php
+++ b/src/Ots/OtsClient.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dew\Acs\Ots;
+
+use Dew\Acs\AcsClient;
+use Dew\Acs\ApiDocsResolver;
+use Dew\Acs\OpenApi\ApiDocs;
+use InvalidArgumentException;
+use Override;
+
+/**
+ * @method \Dew\Acs\Result bindInstance2Vpc(array $arguments = [])
+ * @method \Http\Promise\Promise bindInstance2VpcAsync($arguments = [])
+ * @method \Dew\Acs\Result deleteInstance(array $arguments = [])
+ * @method \Http\Promise\Promise deleteInstanceAsync($arguments = [])
+ * @method \Dew\Acs\Result deleteTags(array $arguments = [])
+ * @method \Http\Promise\Promise deleteTagsAsync($arguments = [])
+ * @method \Dew\Acs\Result getInstance(array $arguments = [])
+ * @method \Http\Promise\Promise getInstanceAsync($arguments = [])
+ * @method \Dew\Acs\Result getOtsServiceStatus(array $arguments = [])
+ * @method \Http\Promise\Promise getOtsServiceStatusAsync($arguments = [])
+ * @method \Dew\Acs\Result insertInstance(array $arguments = [])
+ * @method \Http\Promise\Promise insertInstanceAsync($arguments = [])
+ * @method \Dew\Acs\Result insertTags(array $arguments = [])
+ * @method \Http\Promise\Promise insertTagsAsync($arguments = [])
+ * @method \Dew\Acs\Result listClusterType(array $arguments = [])
+ * @method \Http\Promise\Promise listClusterTypeAsync($arguments = [])
+ * @method \Dew\Acs\Result listInstance(array $arguments = [])
+ * @method \Http\Promise\Promise listInstanceAsync($arguments = [])
+ * @method \Dew\Acs\Result listTags(array $arguments = [])
+ * @method \Http\Promise\Promise listTagsAsync($arguments = [])
+ * @method \Dew\Acs\Result listVpcInfoByInstance(array $arguments = [])
+ * @method \Http\Promise\Promise listVpcInfoByInstanceAsync($arguments = [])
+ * @method \Dew\Acs\Result listVpcInfoByVpc(array $arguments = [])
+ * @method \Http\Promise\Promise listVpcInfoByVpcAsync($arguments = [])
+ * @method \Dew\Acs\Result openOtsService(array $arguments = [])
+ * @method \Http\Promise\Promise openOtsServiceAsync($arguments = [])
+ * @method \Dew\Acs\Result unbindInstance2Vpc(array $arguments = [])
+ * @method \Http\Promise\Promise unbindInstance2VpcAsync($arguments = [])
+ * @method \Dew\Acs\Result updateInstance(array $arguments = [])
+ * @method \Http\Promise\Promise updateInstanceAsync($arguments = [])
+ */
+final class OtsClient extends AcsClient
+{
+    public const DEFAULT_VERSION = '2016-06-20';
+
+    #[Override]
+    protected function resolveApiDocs(): ApiDocs
+    {
+        $version = $this->config['version'] ?? self::DEFAULT_VERSION;
+
+        if (! is_string($version)) {
+            throw new InvalidArgumentException('The version should be a string.');
+        }
+
+        return ApiDocs::make(
+            ApiDocsResolver::make()->getProductDefinition('Ots', $version)
+        );
+    }
+
+    #[Override]
+    protected function resolveEndpoint(): string
+    {
+        return $this->config['endpoint'] ?? sprintf('ots.%s.aliyuncs.com', $this->region);
+    }
+}

--- a/src/Ots/OtsException.php
+++ b/src/Ots/OtsException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dew\Acs\Ots;
+
+use Dew\Acs\AcsException;
+
+final class OtsException extends AcsException
+{
+    //
+}

--- a/src/Tablestore/TablestoreClient.php
+++ b/src/Tablestore/TablestoreClient.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dew\Acs\Tablestore;
+
+use Dew\Acs\AcsClient;
+use Dew\Acs\ApiDocsResolver;
+use Dew\Acs\OpenApi\ApiDocs;
+use InvalidArgumentException;
+use Override;
+
+/**
+ * @method \Dew\Acs\Result changeResourceGroup(array $arguments = [])
+ * @method \Http\Promise\Promise changeResourceGroupAsync($arguments = [])
+ * @method \Dew\Acs\Result createInstance(array $arguments = [])
+ * @method \Http\Promise\Promise createInstanceAsync($arguments = [])
+ * @method \Dew\Acs\Result deleteInstance(array $arguments = [])
+ * @method \Http\Promise\Promise deleteInstanceAsync($arguments = [])
+ * @method \Dew\Acs\Result describeRegions(array $arguments = [])
+ * @method \Http\Promise\Promise describeRegionsAsync($arguments = [])
+ * @method \Dew\Acs\Result getInstance(array $arguments = [])
+ * @method \Http\Promise\Promise getInstanceAsync($arguments = [])
+ * @method \Dew\Acs\Result listInstances(array $arguments = [])
+ * @method \Http\Promise\Promise listInstancesAsync($arguments = [])
+ * @method \Dew\Acs\Result listTagResources(array $arguments = [])
+ * @method \Http\Promise\Promise listTagResourcesAsync($arguments = [])
+ * @method \Dew\Acs\Result tagResources(array $arguments = [])
+ * @method \Http\Promise\Promise tagResourcesAsync($arguments = [])
+ * @method \Dew\Acs\Result untagResources(array $arguments = [])
+ * @method \Http\Promise\Promise untagResourcesAsync($arguments = [])
+ * @method \Dew\Acs\Result updateInstance(array $arguments = [])
+ * @method \Http\Promise\Promise updateInstanceAsync($arguments = [])
+ */
+final class TablestoreClient extends AcsClient
+{
+    public const DEFAULT_VERSION = '2020-12-09';
+
+    #[Override]
+    protected function resolveApiDocs(): ApiDocs
+    {
+        $version = $this->config['version'] ?? self::DEFAULT_VERSION;
+
+        if (! is_string($version)) {
+            throw new InvalidArgumentException('The version should be a string.');
+        }
+
+        return ApiDocs::make(
+            ApiDocsResolver::make()->getProductDefinition('Tablestore', $version)
+        );
+    }
+
+    /**
+     * @see https://github.com/aliyun/terraform-provider-alicloud/blob/5ec9f55e1f5ee8352074e117752d434c96060f47/alicloud/connectivity/endpoint.go#L165
+     */
+    #[Override]
+    protected function resolveEndpoint(): string
+    {
+        return $this->config['endpoint'] ?? sprintf('tablestore.%s.aliyuncs.com', $this->region);
+    }
+}

--- a/src/Tablestore/TablestoreException.php
+++ b/src/Tablestore/TablestoreException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dew\Acs\Tablestore;
+
+use Dew\Acs\AcsException;
+
+final class TablestoreException extends AcsException
+{
+    //
+}

--- a/tests/Ots/OtsClientTest.php
+++ b/tests/Ots/OtsClientTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dew\Acs\Tests\Ots;
+
+use Dew\Acs\Ots\OtsClient;
+use Http\Mock\Client;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @phpstan-import-type TConfig from \Dew\Acs\AcsClient
+ */
+#[CoversClass(OtsClient::class)]
+final class OtsClientTest extends TestCase
+{
+    public function test_endpoint_resolution(): void
+    {
+        $this->assertSame(
+            'ots.cn-hangzhou.aliyuncs.com',
+            $this->makeClient(['region' => 'cn-hangzhou'])->getEndpoint()
+        );
+        $this->assertSame(
+            'ots.cn-shenzhen.aliyuncs.com',
+            $this->makeClient(['region' => 'cn-shenzhen'])->getEndpoint()
+        );
+        $this->assertSame(
+            'example.com',
+            $this->makeClient(['region' => 'us-west-1', 'endpoint' => 'example.com'])->getEndpoint()
+        );
+    }
+
+    /**
+     * @param  TConfig|array<string, mixed>  $config
+     */
+    private function makeClient(array $config = []): OtsClient
+    {
+        /** @var TConfig */
+        $config = [
+            'credentials' => [
+                'key' => 'mykey',
+                'secret' => 'mysecret',
+            ],
+            'region' => 'cn-somewhere',
+            'http_client' => new Client(),
+            ...$config,
+        ];
+
+        return new OtsClient($config);
+    }
+}

--- a/tests/Tablestore/TablestoreClientTest.php
+++ b/tests/Tablestore/TablestoreClientTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dew\Acs\Tests\Tablestore;
+
+use Dew\Acs\Tablestore\TablestoreClient;
+use Http\Mock\Client;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @phpstan-import-type TConfig from \Dew\Acs\AcsClient
+ */
+#[CoversClass(TablestoreClient::class)]
+final class TablestoreClientTest extends TestCase
+{
+    public function test_endpoint_resolution(): void
+    {
+        $this->assertSame(
+            'tablestore.cn-hangzhou.aliyuncs.com',
+            $this->makeClient(['region' => 'cn-hangzhou'])->getEndpoint()
+        );
+        $this->assertSame(
+            'tablestore.cn-shenzhen.aliyuncs.com',
+            $this->makeClient(['region' => 'cn-shenzhen'])->getEndpoint()
+        );
+        $this->assertSame(
+            'example.com',
+            $this->makeClient(['region' => 'us-west-1', 'endpoint' => 'example.com'])->getEndpoint()
+        );
+    }
+
+    /**
+     * @param  TConfig|array<string, mixed>  $config
+     */
+    private function makeClient(array $config = []): TablestoreClient
+    {
+        /** @var TConfig */
+        $config = [
+            'credentials' => [
+                'key' => 'mykey',
+                'secret' => 'mysecret',
+            ],
+            'region' => 'cn-somewhere',
+            'http_client' => new Client(),
+            ...$config,
+        ];
+
+        return new TablestoreClient($config);
+    }
+}


### PR DESCRIPTION
The PR adds support for managing Tablestore and OTS services, which technically refer to the same service but with different product codes and versions, perhaps because Alibaba Cloud has rebranded the product.

These two API docs definition are missing from the OpenAPI metadata _(as of August 6, 2024)_, and I discovered that we can construct back an API docs from pieces of API change-set data of each individual API.

- https://api.aliyun.com/meta/v1/products/Ots/versions/2016-06-20/api-docs.json
- https://api.aliyun.com/meta/v1/products/Tablestore/versions/2020-12-09/api-docs.json

The supported APIs of each product code are taken from the `alibabacloud/sdk` repository:

- ots-20160620
- tablestore-20201209