### PR TITLE
Fix SLS signature mismatch

### DIFF
--- a/src/Oss/V4Signature.php
+++ b/src/Oss/V4Signature.php
@@ -27,7 +27,7 @@ final class V4Signature implements SignsRequest, NeedsArguments
     ) {
         $this->signer->includeAdditionalHeaders();
 
-        $this->signer->preserveHeaders([
+        $this->signer->signHeaders([
             'Content-MD5',
             'Content-Type',
             'X-Oss-*',

--- a/src/Oss/V4SignatureOnUrl.php
+++ b/src/Oss/V4SignatureOnUrl.php
@@ -55,7 +55,7 @@ final class V4SignatureOnUrl implements SignsRequest, NeedsArguments
         );
         $query['x-oss-date'] = $now->format('Ymd\THis\Z');
         $query['x-oss-expires'] = $this->arguments['expires'];
-        $query['x-oss-additional-headers'] = $this->signer->buildAdditionalHeaders($request);
+        $query['x-oss-additional-headers'] = implode(';', $this->signer->buildAdditionalHeaders($request));
 
         if (isset($config['credentials']['token'])) {
             $query['x-oss-security-token'] = $config['credentials']['token'];

--- a/src/Signatures/V4Signature.php
+++ b/src/Signatures/V4Signature.php
@@ -142,19 +142,29 @@ final class V4Signature implements SignsRequest
 
     public function buildCanonicalHeaders(RequestInterface $request): string
     {
-        $headers = $this->onlyIncludeSignedHeadersInCanonical
-            ? $this->buildSignedHeaders($request)
-            : array_keys($request->getHeaders());
-
-        sort($headers, SORT_STRING | SORT_FLAG_CASE);
-
         $result = [];
 
-        foreach ($headers as $name) {
+        foreach ($this->buildCanonicalHeaderNames($request) as $name) {
             $result[] = strtolower($name).':'.$request->getHeaderLine($name);
         }
 
         return implode("\n", $result)."\n";
+    }
+
+    /**
+     * @return string[]
+     */
+    public function buildCanonicalHeaderNames(RequestInterface $request): array
+    {
+        if ($this->onlyIncludeSignedHeadersInCanonical) {
+            return $this->buildSignedHeaders($request);
+        }
+
+        $headers = array_keys($request->getHeaders());
+
+        sort($headers, SORT_STRING | SORT_FLAG_CASE);
+
+        return $headers;
     }
 
     /**

--- a/src/Sls/V4Signature.php
+++ b/src/Sls/V4Signature.php
@@ -19,12 +19,14 @@ final readonly class V4Signature implements SignsRequest
     public function __construct(
         private BaseV4Signature $signer = new BaseV4Signature('SLS4-HMAC-SHA256', 'sls')
     ) {
-        $this->signer->preserveHeaders([
+        $this->signer->signHeaders([
             'Content-Type',
             'Host',
             'X-Acs-*',
             'X-Log-*',
         ]);
+
+        $this->signer->onlyIncludeSignedHeadersInCanonical();
     }
 
     /**

--- a/tests/Oss/V4SignatureTest.php
+++ b/tests/Oss/V4SignatureTest.php
@@ -47,16 +47,17 @@ final class V4SignatureTest extends TestCase
 
     /**
      * @param  array<string, string>  $headers
+     * @param  string[]  $expected
      */
-    #[TestWith([['content-md5' => ''], ''])]
-    #[TestWith([['content-type' => 'application/xml'], ''])]
-    #[TestWith([['x-oss-date' => '2024-01-01T00:00:00Z'], ''])]
-    #[TestWith([['x-foo' => 'bar'], 'x-foo'])]
-    public function test_additional_headers(array $headers, string $expected): void
+    #[TestWith([['content-md5' => ''], []])]
+    #[TestWith([['content-type' => 'application/xml'], []])]
+    #[TestWith([['x-oss-date' => '2024-01-01T00:00:00Z'], []])]
+    #[TestWith([['x-foo' => 'bar'], ['x-foo']])]
+    public function test_additional_headers(array $headers, array $expected): void
     {
         $request = new Request('GET', '/', $headers, '');
         $signer = new V4Signature();
-        $this->assertStringContainsString($expected, $signer->buildAdditionalHeaders($request));
+        $this->assertSame($expected, $signer->buildAdditionalHeaders($request));
     }
 
     /**

--- a/tests/Signatures/V4SignatureTest.php
+++ b/tests/Signatures/V4SignatureTest.php
@@ -99,35 +99,37 @@ final class V4SignatureTest extends TestCase
     }
 
     /**
-     * @param  array<int, string>  $preserved
+     * @param  array<int, string>  $signed
+     * @param  string[]  $expected
      */
-    #[TestWith([[], 'x-bar;x-baz;x-foo'])]
-    #[TestWith([['content-type'], 'x-bar;x-baz;x-foo'])]
-    #[TestWith([['x-foo'], 'x-bar;x-baz'])]
-    #[TestWith([['x-FoO'], 'x-bar;x-baz'])]
-    #[TestWith([['x-Foo'], 'x-bar;x-baz'])]
-    #[TestWith([['x-ba*'], 'x-foo'])]
-    public function test_build_additional_headers(array $preserved, string $expected): void
+    #[TestWith([[], ['x-bar', 'x-baz', 'x-foo']])]
+    #[TestWith([['content-type'], ['x-bar', 'x-baz', 'x-foo']])]
+    #[TestWith([['x-foo'], ['x-bar', 'x-baz']])]
+    #[TestWith([['x-FoO'], ['x-bar', 'x-baz']])]
+    #[TestWith([['x-Foo'], ['x-bar', 'x-baz']])]
+    #[TestWith([['x-ba*'], ['x-foo']])]
+    public function test_build_additional_headers(array $signed, array $expected): void
     {
         $signer = new V4Signature('TEST4-HMAC-SHA256', 'test');
-        $signer->preserveHeaders($preserved);
+        $signer->signHeaders($signed);
         $request = new Request('GET', '/', ['x-FoO' => 'one', 'x-bar' => 'two', 'x-baz' => 'three'], '');
         $this->assertSame($expected, $signer->buildAdditionalHeaders($request));
     }
 
     /**
-     * @param  array<int, string>  $preserved
+     * @param  array<int, string>  $signed
+     * @param  string[]  $expected
      */
-    #[TestWith([['x-foo'], 'x-foo'])]
-    #[TestWith([['x-FoO'], 'x-foo'])]
-    #[TestWith([['x-Foo'], 'x-foo'])]
-    #[TestWith([['x-ba*'], 'x-bar;x-baz'])]
-    #[TestWith([[], ''])]
-    #[TestWith([['content-type'], ''])]
-    public function test_build_signed_headers(array $preserved, string $expected): void
+    #[TestWith([['x-foo'], ['x-foo']])]
+    #[TestWith([['x-FoO'], ['x-foo']])]
+    #[TestWith([['x-Foo'], ['x-foo']])]
+    #[TestWith([['x-ba*'], ['x-bar', 'x-baz']])]
+    #[TestWith([[], []])]
+    #[TestWith([['content-type'], []])]
+    public function test_build_signed_headers(array $signed, array $expected): void
     {
         $signer = new V4Signature('TEST4-HMAC-SHA256', 'test');
-        $signer->preserveHeaders($preserved);
+        $signer->signHeaders($signed);
         $request = new Request('GET', '/', ['x-FoO' => 'one', 'x-bar' => 'two', 'x-baz' => 'three'], '');
         $this->assertSame($expected, $signer->buildSignedHeaders($request));
     }

--- a/tests/Sls/V4SignatureTest.php
+++ b/tests/Sls/V4SignatureTest.php
@@ -65,18 +65,35 @@ final class V4SignatureTest extends TestCase
 
     /**
      * @param  array<string, string>  $headers
+     * @param  string[]  $expected
      */
-    #[TestWith([['content-type' => 'application/json'], 'content-type'])]
-    #[TestWith([['host' => 'example.com'], 'host'])]
-    #[TestWith([['x-acs-foo' => 'bar'], 'x-acs-foo'])]
-    #[TestWith([['x-log-foo' => 'bar'], 'x-log-foo'])]
-    #[TestWith([['x-foo'], ''])]
-    #[TestWith([[], ''])]
-    public function test_signed_headers(array $headers, string $expected): void
+    #[TestWith([['content-type' => 'application/json'], ['content-type']])]
+    #[TestWith([['host' => 'example.com'], ['host']])]
+    #[TestWith([['x-acs-foo' => 'bar'], ['x-acs-foo']])]
+    #[TestWith([['x-log-foo' => 'bar'], ['x-log-foo']])]
+    #[TestWith([['x-foo'], []])]
+    #[TestWith([[], []])]
+    public function test_signed_headers(array $headers, array $expected): void
     {
         $request = new Request('GET', '/', $headers, '');
         $signer = new V4Signature();
         $this->assertSame($expected, $signer->buildSignedHeaders($request));
+    }
+
+    /**
+     * @param  array<string, string>  $headers
+     */
+    #[TestWith([['x-log-foo' => 'bar'], 'x-log-foo:bar'])]
+    #[TestWith([['x-acs-foo' => 'bar'], 'x-acs-foo:bar'])]
+    #[TestWith([['host' => 'example.com'], 'host:example.com'])]
+    #[TestWith([['content-type' => 'application/json'], 'content-type:application/json'])]
+    #[TestWith([['accept' => 'application/json'], ''])]
+    #[TestWith([['user-agent' => 'Awesome'], ''])]
+    public function test_canonical_headers_only_include_signed_headers(array $headers, string $expected): void
+    {
+        $request = new Request('GET', '/', $headers, '');
+        $signer = new V4Signature();
+        $this->assertSame($expected."\n", $signer->buildCanonicalHeaders($request));
     }
 
     public function test_signature_version(): void


### PR DESCRIPTION
The PR fixes (#24) an SLS v4 signature mismatch caused by building canonical headers from all request headers instead of the specified signed headers.