### PR TITLE
SLS: lz4 data compression

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "symfony/var-exporter": "^7.1"
     },
     "suggest": {
+        "ext-lz4": "Allows Protobuf compression with lz4 in SLS",
         "ext-zstd": "Allows Protobuf compression with zstd in SLS",
         "google/protobuf": "Required for Tablestore management."
     },

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -19,3 +19,6 @@ parameters:
         -
             message: '#PHPDoc tag @param for parameter \$key with type key-of<T of array> is not subtype of native type int\|string.#'
             path: src/Arr.php
+        -
+            identifier: function.notFound
+            path: src/Sls/Lz4.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -22,3 +22,4 @@ parameters:
         -
             identifier: function.notFound
             path: src/Sls/Lz4.php
+            reportUnmatched: false

--- a/src/Sls/CompressData.php
+++ b/src/Sls/CompressData.php
@@ -53,6 +53,7 @@ final readonly class CompressData implements Plugin
     private function discoverCompressor(int $size = PHP_INT_MAX): Compression
     {
         return match (true) {
+            Lz4::supports() && $size > Lz4::threshold() => new Lz4(),
             Zstd::supports() && $size > Zstd::threshold() => new Zstd(),
             Deflate::supports() && $size > Deflate::threshold() => new Deflate(),
             default => new Raw(),

--- a/src/Sls/Compression.php
+++ b/src/Sls/Compression.php
@@ -28,7 +28,7 @@ interface Compression
      *
      * @throws \Dew\Acs\Sls\CompressionException
      */
-    public function decode(string $data): string;
+    public function decode(string $data, ?int $maxLength = null): string;
 
     /**
      * The name of the compression algorithm.

--- a/src/Sls/Lz4.php
+++ b/src/Sls/Lz4.php
@@ -6,9 +6,9 @@ namespace Dew\Acs\Sls;
 
 use Override;
 
-final class Deflate implements Compression
+final class Lz4 implements Compression
 {
-    public const int DEFAULT_COMPRESSION_LEVEL = 6;
+    public const int LZ4_FAST_COMPRESSION = 0;
 
     /**
      * {@inheritDoc}
@@ -16,7 +16,7 @@ final class Deflate implements Compression
     #[Override]
     public static function supports(): bool
     {
-        return extension_loaded('zlib');
+        return extension_loaded('lz4');
     }
 
     /**
@@ -34,8 +34,8 @@ final class Deflate implements Compression
     #[Override]
     public function encode(string $data, ?int $level = null): string
     {
-        $level = is_int($level) ? $level : self::DEFAULT_COMPRESSION_LEVEL;
-        $encoded = gzcompress($data, $level);
+        $level = is_int($level) ? $level : self::LZ4_FAST_COMPRESSION;
+        $encoded = lz4compress($data, $level);
 
         if ($encoded === false) {
             throw new CompressionException('Could not encode the data.');
@@ -50,7 +50,11 @@ final class Deflate implements Compression
     #[Override]
     public function decode(string $data, ?int $maxLength = null): string
     {
-        $decoded = gzuncompress($data, $maxLength ?? 0);
+        if ($maxLength === null) {
+            throw new CompressionException('Requires original data size.');
+        }
+
+        $decoded = lz4uncompress($data, $maxLength);
 
         if ($decoded === false) {
             throw new CompressionException('Could not decode the data.');
@@ -65,6 +69,6 @@ final class Deflate implements Compression
     #[Override]
     public function format(): string
     {
-        return 'deflate';
+        return 'lz4';
     }
 }

--- a/src/Sls/Lz4.php
+++ b/src/Sls/Lz4.php
@@ -50,11 +50,7 @@ final class Lz4 implements Compression
     #[Override]
     public function decode(string $data, ?int $maxLength = null): string
     {
-        if ($maxLength === null) {
-            throw new CompressionException('Requires original data size.');
-        }
-
-        $decoded = lz4uncompress($data, $maxLength);
+        $decoded = lz4uncompress($data, $maxLength ?? 0);
 
         if ($decoded === false) {
             throw new CompressionException('Could not decode the data.');

--- a/src/Sls/Raw.php
+++ b/src/Sls/Raw.php
@@ -39,7 +39,7 @@ final class Raw implements Compression
      * {@inheritDoc}
      */
     #[Override]
-    public function decode(string $data): string
+    public function decode(string $data, ?int $maxLength = null): string
     {
         return $data;
     }

--- a/src/Sls/Zstd.php
+++ b/src/Sls/Zstd.php
@@ -51,7 +51,7 @@ final class Zstd implements Compression
      * {@inheritDoc}
      */
     #[Override]
-    public function decode(string $data): string
+    public function decode(string $data, ?int $maxLength = null): string
     {
         $decoded = uncompress($data);
 

--- a/tests/Sls/Lz4Test.php
+++ b/tests/Sls/Lz4Test.php
@@ -7,9 +7,11 @@ namespace Dew\Acs\Tests\Sls;
 use Dew\Acs\Sls\CompressionException;
 use Dew\Acs\Sls\Lz4;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(Lz4::class)]
+#[RequiresPhpExtension('lz4')]
 final class Lz4Test extends TestCase
 {
     public function test_encode_and_decode(): void

--- a/tests/Sls/Lz4Test.php
+++ b/tests/Sls/Lz4Test.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Dew\Acs\Tests\Sls;
 
-use Dew\Acs\Sls\CompressionException;
 use Dew\Acs\Sls\Lz4;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
@@ -25,11 +24,10 @@ final class Lz4Test extends TestCase
         $this->assertTrue($decoded === $data);
     }
 
-    public function test_decode_requires_original_data_size(): void
+    public function test_decode_without_original_data_size(): void
     {
-        $this->expectException(CompressionException::class);
-        $this->expectExceptionMessage('Requires original data size.');
         $lz4 = new Lz4();
-        $lz4->decode($lz4->encode(str_repeat('a', 64)));
+        $data = str_repeat('a', 64);
+        $this->assertSame($data, $lz4->decode($lz4->encode($data)));
     }
 }

--- a/tests/Sls/Lz4Test.php
+++ b/tests/Sls/Lz4Test.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dew\Acs\Tests\Sls;
+
+use Dew\Acs\Sls\CompressionException;
+use Dew\Acs\Sls\Lz4;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Lz4::class)]
+final class Lz4Test extends TestCase
+{
+    public function test_encode_and_decode(): void
+    {
+        $lz4 = new Lz4();
+        $data = str_repeat('a', $len = 64);
+        $encoded = $lz4->encode($data);
+        $this->assertTrue(strlen($encoded) < $len);
+        $this->assertTrue($encoded !== $data);
+        $decoded = $lz4->decode($encoded, $len);
+        $this->assertTrue($decoded === $data);
+    }
+
+    public function test_decode_requires_original_data_size(): void
+    {
+        $this->expectException(CompressionException::class);
+        $this->expectExceptionMessage('Requires original data size.');
+        $lz4 = new Lz4();
+        $lz4->decode($lz4->encode(str_repeat('a', 64)));
+    }
+}


### PR DESCRIPTION
The PR brings support for lz4 data compression to SLS with the in-house [PHP lz4-binding extension](https://github.com/dew-serverless/php-ext-lz4).

Closes #25.

## Benchmark

Ran on MacBook Air M2, the file is located at _benchmark/sls/compression.php_.

```

=> deflate: simple (protobuf)
 92 bytes	[deflate: 1]  99 bytes	 8%  0.12ms
 92 bytes	[deflate: 2]  99 bytes	 8%  0.01ms
 92 bytes	[deflate: 3]  99 bytes	 8%  0ms
 92 bytes	[deflate: 4]  99 bytes	 8%  0ms
 92 bytes	[deflate: 5]  99 bytes	 8%  0ms
 92 bytes	[deflate: 6]  99 bytes	 8%  0ms
 92 bytes	[deflate: 7]  99 bytes	 8%  0ms
 92 bytes	[deflate: 8]  99 bytes	 8%  0ms
 92 bytes	[deflate: 9]  99 bytes	 8%  0ms

=> zstd: simple (protobuf)
 92 bytes	[zstd: 1] 101 bytes	10%  2.19ms
 92 bytes	[zstd: 2] 101 bytes	10%  0ms
 92 bytes	[zstd: 3] 101 bytes	10%  0.1ms
 92 bytes	[zstd: 4] 101 bytes	10%  0ms
 92 bytes	[zstd: 5] 101 bytes	10%  0ms
 92 bytes	[zstd: 6] 101 bytes	10%  0.22ms
 92 bytes	[zstd: 7] 101 bytes	10%  0ms
 92 bytes	[zstd: 8] 101 bytes	10%  0ms
 92 bytes	[zstd: 9] 101 bytes	10%  0.43ms
 92 bytes	[zstd:10] 101 bytes	10%  0.01ms
 92 bytes	[zstd:11] 101 bytes	10%  0.09ms
 92 bytes	[zstd:12] 101 bytes	10%  0ms
 92 bytes	[zstd:13] 101 bytes	10%  0.08ms
 92 bytes	[zstd:14] 101 bytes	10%  0ms
 92 bytes	[zstd:15] 101 bytes	10%  0ms
 92 bytes	[zstd:16] 101 bytes	10%  0.15ms
 92 bytes	[zstd:17] 101 bytes	10%  0ms
 92 bytes	[zstd:18] 101 bytes	10%  0ms
 92 bytes	[zstd:19] 101 bytes	10%  0ms
 92 bytes	[zstd:20] 101 bytes	10%  0ms
 92 bytes	[zstd:21] 101 bytes	10%  0ms
 92 bytes	[zstd:22] 101 bytes	10%  0ms

=> lz4: simple (protobuf)
 92 bytes	[lz4: 0]  94 bytes	 3%  0.34ms
 92 bytes	[lz4: 1]  94 bytes	 3%  0.52ms
 92 bytes	[lz4: 2]  94 bytes	 3%  0.04ms
 92 bytes	[lz4: 3]  94 bytes	 3%  0ms
 92 bytes	[lz4: 4]  94 bytes	 3%  0ms
 92 bytes	[lz4: 5]  94 bytes	 3%  0ms
 92 bytes	[lz4: 6]  94 bytes	 3%  0ms
 92 bytes	[lz4: 7]  94 bytes	 3%  0ms
 92 bytes	[lz4: 8]  94 bytes	 3%  0ms
 92 bytes	[lz4: 9]  94 bytes	 3%  0ms
 92 bytes	[lz4:10]  94 bytes	 3%  0ms
 92 bytes	[lz4:11]  94 bytes	 3%  0ms
 92 bytes	[lz4:12]  94 bytes	 3%  0ms

=> deflate: user login (protobuf)
194 bytes	[deflate: 1] 183 bytes	-5%  0.02ms
194 bytes	[deflate: 2] 183 bytes	-5%  0.01ms
194 bytes	[deflate: 3] 183 bytes	-5%  0.01ms
194 bytes	[deflate: 4] 183 bytes	-5%  0.01ms
194 bytes	[deflate: 5] 183 bytes	-5%  0.01ms
194 bytes	[deflate: 6] 183 bytes	-5%  0.01ms
194 bytes	[deflate: 7] 183 bytes	-5%  0.01ms
194 bytes	[deflate: 8] 183 bytes	-5%  0.01ms
194 bytes	[deflate: 9] 183 bytes	-5%  0.01ms

=> zstd: user login (protobuf)
194 bytes	[zstd: 1] 190 bytes	-2%  0.02ms
194 bytes	[zstd: 2] 189 bytes	-2%  0.01ms
194 bytes	[zstd: 3] 189 bytes	-2%  0.01ms
194 bytes	[zstd: 4] 189 bytes	-2%  0ms
194 bytes	[zstd: 5] 189 bytes	-2%  0.01ms
194 bytes	[zstd: 6] 189 bytes	-2%  0.01ms
194 bytes	[zstd: 7] 189 bytes	-2%  0ms
194 bytes	[zstd: 8] 189 bytes	-2%  0ms
194 bytes	[zstd: 9] 189 bytes	-2%  0.01ms
194 bytes	[zstd:10] 189 bytes	-2%  0.01ms
194 bytes	[zstd:11] 189 bytes	-2%  0.02ms
194 bytes	[zstd:12] 189 bytes	-2%  0.01ms
194 bytes	[zstd:13] 188 bytes	-3%  0.01ms
194 bytes	[zstd:14] 188 bytes	-3%  0.01ms
194 bytes	[zstd:15] 188 bytes	-3%  0.01ms
194 bytes	[zstd:16] 188 bytes	-3%  0.01ms
194 bytes	[zstd:17] 188 bytes	-3%  0.01ms
194 bytes	[zstd:18] 188 bytes	-3%  0.01ms
194 bytes	[zstd:19] 188 bytes	-3%  0.01ms
194 bytes	[zstd:20] 188 bytes	-3%  0.01ms
194 bytes	[zstd:21] 188 bytes	-3%  0.01ms
194 bytes	[zstd:22] 188 bytes	-3%  0.01ms

=> lz4: user login (protobuf)
194 bytes	[lz4: 0] 190 bytes	-2%  0ms
194 bytes	[lz4: 1] 190 bytes	-2%  0.01ms
194 bytes	[lz4: 2] 190 bytes	-2%  0ms
194 bytes	[lz4: 3] 190 bytes	-2%  0ms
194 bytes	[lz4: 4] 190 bytes	-2%  0ms
194 bytes	[lz4: 5] 190 bytes	-2%  0ms
194 bytes	[lz4: 6] 190 bytes	-2%  0ms
194 bytes	[lz4: 7] 190 bytes	-2%  0ms
194 bytes	[lz4: 8] 190 bytes	-2%  0ms
194 bytes	[lz4: 9] 190 bytes	-2%  0ms
194 bytes	[lz4:10] 190 bytes	-2%  0ms
194 bytes	[lz4:11] 190 bytes	-2%  0ms
194 bytes	[lz4:12] 190 bytes	-2%  0ms

=> deflate: nginx (protobuf)
399 bytes	[deflate: 1] 343 bytes	-14%  0.03ms
399 bytes	[deflate: 2] 343 bytes	-14%  0.02ms
399 bytes	[deflate: 3] 343 bytes	-14%  0.01ms
399 bytes	[deflate: 4] 343 bytes	-14%  0.02ms
399 bytes	[deflate: 5] 343 bytes	-14%  0.02ms
399 bytes	[deflate: 6] 343 bytes	-14%  0.01ms
399 bytes	[deflate: 7] 343 bytes	-14%  0.01ms
399 bytes	[deflate: 8] 343 bytes	-14%  0.01ms
399 bytes	[deflate: 9] 343 bytes	-14%  0.01ms

=> zstd: nginx (protobuf)
399 bytes	[zstd: 1] 368 bytes	-7%  0.01ms
399 bytes	[zstd: 2] 366 bytes	-8%  0.01ms
399 bytes	[zstd: 3] 367 bytes	-8%  0.01ms
399 bytes	[zstd: 4] 366 bytes	-8%  0.01ms
399 bytes	[zstd: 5] 366 bytes	-8%  0.01ms
399 bytes	[zstd: 6] 366 bytes	-8%  0.01ms
399 bytes	[zstd: 7] 366 bytes	-8%  0.01ms
399 bytes	[zstd: 8] 366 bytes	-8%  0.01ms
399 bytes	[zstd: 9] 366 bytes	-8%  0.01ms
399 bytes	[zstd:10] 366 bytes	-8%  0.01ms
399 bytes	[zstd:11] 365 bytes	-8%  0.02ms
399 bytes	[zstd:12] 365 bytes	-8%  0.02ms
399 bytes	[zstd:13] 366 bytes	-8%  0.02ms
399 bytes	[zstd:14] 366 bytes	-8%  0.01ms
399 bytes	[zstd:15] 366 bytes	-8%  0.01ms
399 bytes	[zstd:16] 366 bytes	-8%  0.02ms
399 bytes	[zstd:17] 366 bytes	-8%  0.01ms
399 bytes	[zstd:18] 366 bytes	-8%  0.01ms
399 bytes	[zstd:19] 366 bytes	-8%  0.01ms
399 bytes	[zstd:20] 366 bytes	-8%  0.01ms
399 bytes	[zstd:21] 366 bytes	-8%  0.01ms
399 bytes	[zstd:22] 366 bytes	-8%  0.01ms

=> lz4: nginx (protobuf)
399 bytes	[lz4: 0] 388 bytes	-2%  0ms
399 bytes	[lz4: 1] 386 bytes	-3%  0ms
399 bytes	[lz4: 2] 386 bytes	-3%  0ms
399 bytes	[lz4: 3] 386 bytes	-3%  0ms
399 bytes	[lz4: 4] 386 bytes	-3%  0ms
399 bytes	[lz4: 5] 386 bytes	-3%  0ms
399 bytes	[lz4: 6] 386 bytes	-3%  0ms
399 bytes	[lz4: 7] 386 bytes	-3%  0ms
399 bytes	[lz4: 8] 386 bytes	-3%  0ms
399 bytes	[lz4: 9] 386 bytes	-3%  0ms
399 bytes	[lz4:10] 386 bytes	-3%  0.01ms
399 bytes	[lz4:11] 386 bytes	-3%  0ms
399 bytes	[lz4:12] 386 bytes	-3%  0.01ms

=> deflate: lorem ipsum
574 bytes	[deflate: 1] 338 bytes	-41%  0.03ms
574 bytes	[deflate: 2] 339 bytes	-40%  0.02ms
574 bytes	[deflate: 3] 338 bytes	-41%  0.01ms
574 bytes	[deflate: 4] 337 bytes	-41%  0.02ms
574 bytes	[deflate: 5] 337 bytes	-41%  0.02ms
574 bytes	[deflate: 6] 337 bytes	-41%  0.01ms
574 bytes	[deflate: 7] 337 bytes	-41%  0.02ms
574 bytes	[deflate: 8] 337 bytes	-41%  0.01ms
574 bytes	[deflate: 9] 337 bytes	-41%  0.01ms

=> zstd: lorem ipsum
574 bytes	[zstd: 1] 351 bytes	-38%  0.01ms
574 bytes	[zstd: 2] 353 bytes	-38%  0.01ms
574 bytes	[zstd: 3] 352 bytes	-38%  0.01ms
574 bytes	[zstd: 4] 349 bytes	-39%  0.01ms
574 bytes	[zstd: 5] 346 bytes	-39%  0.01ms
574 bytes	[zstd: 6] 346 bytes	-39%  0.01ms
574 bytes	[zstd: 7] 346 bytes	-39%  0.01ms
574 bytes	[zstd: 8] 346 bytes	-39%  0ms
574 bytes	[zstd: 9] 346 bytes	-39%  0.01ms
574 bytes	[zstd:10] 346 bytes	-39%  0.01ms
574 bytes	[zstd:11] 345 bytes	-39%  0.03ms
574 bytes	[zstd:12] 345 bytes	-39%  0.03ms
574 bytes	[zstd:13] 347 bytes	-39%  0.03ms
574 bytes	[zstd:14] 347 bytes	-39%  0.02ms
574 bytes	[zstd:15] 347 bytes	-39%  0.02ms
574 bytes	[zstd:16] 347 bytes	-39%  0.03ms
574 bytes	[zstd:17] 347 bytes	-39%  0.02ms
574 bytes	[zstd:18] 347 bytes	-39%  0.02ms
574 bytes	[zstd:19] 347 bytes	-39%  0.02ms
574 bytes	[zstd:20] 347 bytes	-39%  0.02ms
574 bytes	[zstd:21] 347 bytes	-39%  0.02ms
574 bytes	[zstd:22] 347 bytes	-39%  0.02ms

=> lz4: lorem ipsum
574 bytes	[lz4: 0] 504 bytes	-12%  0ms
574 bytes	[lz4: 1] 501 bytes	-12%  0ms
574 bytes	[lz4: 2] 501 bytes	-12%  0ms
574 bytes	[lz4: 3] 500 bytes	-12%  0ms
574 bytes	[lz4: 4] 500 bytes	-12%  0ms
574 bytes	[lz4: 5] 500 bytes	-12%  0ms
574 bytes	[lz4: 6] 500 bytes	-12%  0ms
574 bytes	[lz4: 7] 500 bytes	-12%  0ms
574 bytes	[lz4: 8] 500 bytes	-12%  0ms
574 bytes	[lz4: 9] 500 bytes	-12%  0ms
574 bytes	[lz4:10] 500 bytes	-12%  0.01ms
574 bytes	[lz4:11] 500 bytes	-12%  0.01ms
574 bytes	[lz4:12] 497 bytes	-13%  0.01ms
```