### PR TITLE
CI: Update OpenAPI metadata weekly

### DIFF
--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -68,6 +68,7 @@ jobs:
             git push origin update-metadata-$NOW
             gh pr create \
               --base main \
+              --head update-metadata-$NOW \
               --title "Update OpenAPI metadata $NOW" \
               --body "Here are the API changes during the week, check the metadata and update with the latest Alibaba Cloud APIs."
           fi

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   metadata:
+    name: Update metadata
     runs-on: ubuntu-latest
     if: contains(github.event.pull_request.labels.*.name, 'update-metadata')
 

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -57,3 +57,5 @@ jobs:
             --base main \
             --title "Update OpenAPI metadata $(date '+%Y%m%d')" \
             --body "Here are the API changes during the week, check the metadata and update with the latest Alibaba Cloud APIs."
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -4,15 +4,11 @@ on:
   schedule:
     - cron: "30 3 * * 6"   # At 03:30 on Saturday
   workflow_dispatch:
-  pull_request:
-    types:
-      - labeled
 
 jobs:
   metadata:
     name: Update metadata
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'update-metadata')
 
     permissions:
       contents: write

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -61,11 +61,15 @@ jobs:
 
       - name: Create a Pull Request
         run: |
-          if ! git diff --quiet main..HEAD; then
+          if ! git diff --quiet $GITHUB_SHA..HEAD; then
+            NOW="$(date '+%Y%m%d')"
+            git branch update-metadata-$NOW
+            git push origin update-metadata-$NOW
             gh pr create \
               --base main \
-              --title "Update OpenAPI metadata $(date '+%Y%m%d')" \
+              --title "Update OpenAPI metadata $NOW" \
               --body "Here are the API changes during the week, check the metadata and update with the latest Alibaba Cloud APIs."
           fi
         env:
           GH_TOKEN: ${{ github.token }}
+          GITHUB_SHA: ${{ github.sha }}

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -4,10 +4,14 @@ on:
   schedule:
     - cron: "30 3 * * 6"   # At 03:30 on Saturday
   workflow_dispatch:
+  pull_request:
+    types:
+      - labeled
 
 jobs:
   metadata:
     runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'update-metadata')
 
     permissions:
       pull-requests: write

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -14,6 +14,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'update-metadata')
 
     permissions:
+      contents: write
       pull-requests: write
 
     steps:

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -40,6 +40,8 @@ jobs:
 
       - name: Commit metadata changes
         run: |
+          git add data/products.php
+          git commit -m "update products"
           git add .
           git commit -m "update metadata"
 

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -1,0 +1,55 @@
+name: Update OpenAPI metadata
+
+on:
+  schedule:
+    - cron: "30 3 * * 6"   # At 03:30 on Saturday
+  workflow_dispatch:
+
+jobs:
+  metadata:
+    runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          tools: composer:v2
+          coverage: none
+
+      - name: Install Dependencies
+        run: composer update --prefer-stable --no-interaction --no-progress --ansi
+
+      - name: Git config
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch metadata
+        run: make fetch-meta
+
+      - name: Commit metadata changes
+        run: |
+          git add .
+          git commit -m "update metadata"
+
+      - name: Build clients
+        run: make build-clients
+
+      - name: Commit updated clients
+        run: |
+          git add .
+          git commit -m "build clients"
+
+      - name: Create a Pull Request
+        run: |
+          gh pr create \
+            --base main \
+            --title "Update OpenAPI metadata $(date '+%Y%m%d')" \
+            --body "Here are the API changes during the week, check the metadata and update with the latest Alibaba Cloud APIs."

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -40,24 +40,32 @@ jobs:
 
       - name: Commit metadata changes
         run: |
-          git add data/products.php
-          git commit -m "update products"
-          git add .
-          git commit -m "update metadata"
+          if ! git diff --quiet data/products.php; then
+            git add data/products.php
+            git commit -m "update products"
+          fi
+          if ! git diff --quiet data/; then
+            git add .
+            git commit -m "update metadata"
+          fi
 
       - name: Build clients
         run: make build-clients
 
       - name: Commit updated clients
         run: |
-          git add .
-          git commit -m "build clients"
+          if ! git diff --quiet src/; then
+            git add .
+            git commit -m "build clients"
+          fi
 
       - name: Create a Pull Request
         run: |
-          gh pr create \
-            --base main \
-            --title "Update OpenAPI metadata $(date '+%Y%m%d')" \
-            --body "Here are the API changes during the week, check the metadata and update with the latest Alibaba Cloud APIs."
+          if ! git diff --quiet main..HEAD; then
+            gh pr create \
+              --base main \
+              --title "Update OpenAPI metadata $(date '+%Y%m%d')" \
+              --body "Here are the API changes during the week, check the metadata and update with the latest Alibaba Cloud APIs."
+          fi
         env:
           GH_TOKEN: ${{ github.token }}

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
+ACS_ENDPOINT ?= https://api.alibabacloud.com
 PROTOC ?= protoc
 PROTO_SRC_DIR = protobuf
 PROTO_GEN_DIR = src
 
 fetch-meta:
-	php build/fetch-meta.php
+	ACS_ENDPOINT=$(ACS_ENDPOINT) php build/fetch-meta.php
 
 build-clients:
 	php build/build-clients.php

--- a/build/fetch-meta.php
+++ b/build/fetch-meta.php
@@ -8,6 +8,18 @@ require_once __DIR__.'/ApiDocsStripper.php';
 
 use Symfony\Component\VarExporter\VarExporter;
 
+function getEndpoint(): string
+{
+    $endpoint = getenv('ACS_ENDPOINT');
+
+    return is_string($endpoint) ? $endpoint : 'https://api.alibabacloud.com';
+}
+
+function withEndpoint(string $url): string
+{
+    return sprintf('%s/%s', rtrim(getEndpoint(), '/'), ltrim($url, '/'));
+}
+
 function getContents(string $url): string
 {
     $stream = fopen($url, 'r');
@@ -31,10 +43,9 @@ function getContents(string $url): string
  */
 function getApiDocs(string $product, string $version): array
 {
-    $contents = getContents(sprintf(
-        'https://api.aliyun.com/meta/v1/products/%s/versions/%s/api-docs.json',
-        $product, $version
-    ));
+    $contents = getContents(withEndpoint(sprintf(
+        '/meta/v1/products/%s/versions/%s/api-docs.json', $product, $version
+    )));
 
     $decoded = json_decode(
         $contents, associative: true, flags: JSON_THROW_ON_ERROR
@@ -52,10 +63,9 @@ function getApiDocs(string $product, string $version): array
  */
 function getLatestApiChanges(string $product, string $version, string $api): array
 {
-    $contents = getContents(sprintf(
-        'https://api.aliyun.com/api/changeset/%s/%s/%s?page=1&pageSize=1',
-        $product, $version, $api
-    ));
+    $contents = getContents(withEndpoint(sprintf(
+        '/api/changeset/%s/%s/%s?page=1&pageSize=1', $product, $version, $api
+    )));
 
     $decoded = json_decode(
         $contents, associative: true, flags: JSON_THROW_ON_ERROR
@@ -210,7 +220,7 @@ function buildFromChangeset(string $product, string $version, string $style, arr
 function main(): int
 {
     echo '=> Updating product list'.PHP_EOL;
-    updateProductList('https://api.aliyun.com/meta/v1/products.json');
+    updateProductList(withEndpoint('/meta/v1/products.json'));
 
     buildFromProducts();
 


### PR DESCRIPTION
Use the Github action to launch a PR with OpenAPI metadata update every Saturday at 3:30 AM to relieve developers of this repetitive task.

Let's give it a shot on a weekly basis, a longer interval may lead to outdated API description files, while a shorter interval might result in unnecessary updates, as APIs typically don't change daily.

Once the PR is created, we have a week to review the changes and prepare for any upcoming changes.

Closes #30.