### PR TITLE
Fetch specific product metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 ACS_ENDPOINT ?= https://api.alibabacloud.com
+ACS_PRODUCTS ?=
 PROTOC ?= protoc
 PROTO_SRC_DIR = protobuf
 PROTO_GEN_DIR = src
 
 fetch-meta:
-	ACS_ENDPOINT=$(ACS_ENDPOINT) php build/fetch-meta.php
+	ACS_ENDPOINT=$(ACS_ENDPOINT) ACS_PRODUCTS=$(ACS_PRODUCTS) php build/fetch-meta.php
 
 build-clients:
 	php build/build-clients.php


### PR DESCRIPTION
Alibaba Cloud offers a wide range of services, and building them from start to finish can be time-consuming and challenging, especially when it comes to debugging or retrieving metadata for specific products. This pull request introduces a feature that allows you to request metadata for specific products more efficiently.

For example, if you only need to build metadata for the _SAE_ service, you can use the following command:

```bash
ACS_PRODUCTS=sae make fetch-meta
```

Additionally, you can build metadata for multiple products simultaneously by listing their product codes, separated by commas. For example:

```bash
ACS_PRODUCTS=sae,vpc make fetch-meta
```