### PR TITLE
Flat style on RPC parameter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,11 @@
     "type": "library",
     "require": {
         "php": "^8.3",
-        "psr/http-client-implementation": "^1.0",
+        "guzzlehttp/psr7": "^2.7",
+        "php-http/client-common": "^2.7",
         "php-http/discovery": "^1.0",
-        "psr/http-factory": "^1.1",
-        "php-http/client-common": "^2.7"
+        "psr/http-client-implementation": "^1.0",
+        "psr/http-factory": "^1.1"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.59",

--- a/src/OpenApi/ROAStyleBuilder.php
+++ b/src/OpenApi/ROAStyleBuilder.php
@@ -7,6 +7,7 @@ namespace Dew\Acs\OpenApi;
 use Dew\Acs\JsonEncoder;
 use Dew\Acs\Str;
 use Dew\Acs\XmlEncoder;
+use GuzzleHttp\Psr7\Query;
 use InvalidArgumentException;
 use Override;
 use RuntimeException;
@@ -131,7 +132,7 @@ final readonly class ROAStyleBuilder implements ApiDataBuilder
             method: strtoupper($this->api->methods[0]),
             headers: $headers,
             path: $path,
-            query: http_build_query($query, encoding_type: PHP_QUERY_RFC3986),
+            query: Query::build($query, PHP_QUERY_RFC3986),
             body: $body
         );
     }
@@ -147,7 +148,7 @@ final readonly class ROAStyleBuilder implements ApiDataBuilder
         $query = [];
 
         if (isset($parsed['query'])) {
-            parse_str($parsed['query'], $query);
+            $query = Query::parse($parsed['query']);
         }
 
         return [$path, $query];

--- a/src/OpenApi/ROAStyleBuilder.php
+++ b/src/OpenApi/ROAStyleBuilder.php
@@ -132,7 +132,7 @@ final readonly class ROAStyleBuilder implements ApiDataBuilder
             method: strtoupper($this->api->methods[0]),
             headers: $headers,
             path: $path,
-            query: Query::build($query, PHP_QUERY_RFC3986),
+            query: Query::build($query),
             body: $body
         );
     }

--- a/src/OpenApi/RPCStyleBuilder.php
+++ b/src/OpenApi/RPCStyleBuilder.php
@@ -93,7 +93,7 @@ final readonly class RPCStyleBuilder implements ApiDataBuilder
         }
 
         return match ($parameter->style) {
-            'repeatList' => $this->encodeRepeatListStyle(
+            'repeatList', 'flat' => $this->encodeRepeatListStyle(
                 array_is_list($value) ? $this->shiftKey($value, 1) : $value,
                 $parameter->name
             ),

--- a/src/OpenApi/RPCStyleBuilder.php
+++ b/src/OpenApi/RPCStyleBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Dew\Acs\OpenApi;
 
+use GuzzleHttp\Psr7\Query;
 use InvalidArgumentException;
 use Override;
 use RuntimeException;
@@ -69,7 +70,7 @@ final readonly class RPCStyleBuilder implements ApiDataBuilder
         if ($formData !== []) {
             $method = 'POST';
             $headers['Content-Type'] = 'application/x-www-form-urlencoded';
-            $body = http_build_query($formData);
+            $body = Query::build($formData, PHP_QUERY_RFC1738);
         }
 
         return new ApiData(
@@ -78,7 +79,7 @@ final readonly class RPCStyleBuilder implements ApiDataBuilder
             method: $method,
             path: '/',
             headers: $headers,
-            query: http_build_query($query, encoding_type: PHP_QUERY_RFC3986),
+            query: Query::build($query),
             body: $body
         );
     }

--- a/src/Signatures/V3Signature.php
+++ b/src/Signatures/V3Signature.php
@@ -9,6 +9,7 @@ use DateTimeZone;
 use Dew\Acs\ConfigChecker;
 use Dew\Acs\OpenApi\Api;
 use Dew\Acs\OpenApi\ApiDocs;
+use GuzzleHttp\Psr7\Query;
 use Override;
 use Psr\Http\Message\RequestInterface;
 use RuntimeException;
@@ -119,8 +120,7 @@ final class V3Signature implements SignsRequest, NeedsApiContext
 
     public function getCanonicalQueryString(RequestInterface $request): string
     {
-        $query = [];
-        parse_str($request->getUri()->getQuery(), $query);
+        $query = Query::parse($request->getUri()->getQuery());
 
         if ($query === []) {
             return '';
@@ -132,10 +132,10 @@ final class V3Signature implements SignsRequest, NeedsApiContext
         $delimiter = '';
 
         foreach ($query as $key => $value) {
-            $key = (string) $key;
+            $key = rawurlencode((string) $key);
             $value = is_array($value) ? implode(',', $value) : $value;
-            $pair = rawurlencode($key).'='.rawurlencode($value);
-            $result .= $delimiter.$pair;
+            $value = is_string($value) ? rawurlencode($value) : '';
+            $result .= $delimiter.$key.'='.$value;
             $delimiter = '&';
         }
 

--- a/src/Signatures/V4Signature.php
+++ b/src/Signatures/V4Signature.php
@@ -8,6 +8,7 @@ use DateTimeInterface;
 use DateTimeZone;
 use Dew\Acs\ConfigChecker;
 use Dew\Acs\Str;
+use GuzzleHttp\Psr7\Query;
 use Override;
 use Psr\Http\Message\RequestInterface;
 
@@ -123,13 +124,13 @@ final class V4Signature implements SignsRequest
 
     public function buildCanonicalQueryString(RequestInterface $request): string
     {
-        $query = [];
-        parse_str($request->getUri()->getQuery(), $query);
+        $query = Query::parse($request->getUri()->getQuery());
 
         $sorted = [];
         foreach ($query as $key => $value) {
             $key = rawurlencode((string) $key);
-            $value = rawurlencode(is_array($value) ? implode('&', $value) : $value);
+            $value = is_array($value) ? implode('&', $value) : $value;
+            $value = is_string($value) ? rawurlencode($value) : '';
             $sorted[$key] = $value;
         }
         ksort($sorted);

--- a/src/Sls/V1Signature.php
+++ b/src/Sls/V1Signature.php
@@ -8,6 +8,7 @@ use DateTimeImmutable;
 use DateTimeZone;
 use Dew\Acs\ConfigChecker;
 use Dew\Acs\Signatures\SignsRequest;
+use GuzzleHttp\Psr7\Query;
 use Override;
 use Psr\Http\Message\RequestInterface;
 
@@ -112,8 +113,7 @@ final readonly class V1Signature implements SignsRequest
 
     public function getSortedQuery(RequestInterface $request): string
     {
-        $query = [];
-        parse_str($request->getUri()->getQuery(), $query);
+        $query = Query::parse($request->getUri()->getQuery());
         ksort($query);
 
         $result = '';

--- a/tests/OpenApi/ROAStyleBuilderTest.php
+++ b/tests/OpenApi/ROAStyleBuilderTest.php
@@ -303,7 +303,7 @@ final class ROAStyleBuilderTest extends TestCase
         $api = $this->makeApi(['path' => '/?foo']);
         $builder = new ROAStyleBuilder($docs, $api);
         $data = $builder->build([]);
-        $this->assertSame('foo=', $data->query);
+        $this->assertSame('foo', $data->query);
     }
 
     public function test_query_resolution_nullable(): void

--- a/tests/OpenApi/RPCStyleBuilderTest.php
+++ b/tests/OpenApi/RPCStyleBuilderTest.php
@@ -90,14 +90,16 @@ final class RPCStyleBuilderTest extends TestCase
         $this->assertSame('page=1', $argument->query);
     }
 
-    public function test_query_resolution_repeat_list_style(): void
+    #[TestWith(['repeatList'], 'repeat list')]
+    #[TestWith(['flat'], 'flat')]
+    public function test_query_resolution_style(string $style): void
     {
         $docs = $this->makeApiDocs();
         $api = $this->makeApi([
             'parameters' => [[
                 'name' => 'tag',
                 'in' => 'query',
-                'style' => 'repeatList',
+                'style' => $style,
                 'schema' => [
                     'type' => 'array',
                     'items' => [

--- a/tests/Oss/V4SignatureOnUrlTest.php
+++ b/tests/Oss/V4SignatureOnUrlTest.php
@@ -59,8 +59,8 @@ final class V4SignatureOnUrlTest extends TestCase
         $this->assertStringContainsString('x-oss-security-token=mytoken', $uri);
     }
 
-    #[TestWith(['https://example.com?foo', 'foo='])]
-    #[TestWith(['https://example.com?foo=', 'foo='])]
+    #[TestWith(['https://example.com?foo', 'foo'])]
+    #[TestWith(['https://example.com?foo=', 'foo'])]
     #[TestWith(['https://example.com?foo=bar', 'foo=bar'])]
     public function test_sign_request_existing_query(string $uri, string $expected): void
     {


### PR DESCRIPTION
The PR adds support for encoding the _flat_ style parameter in the RPC API. The _flat_ style is essentially an alias for the _repeatList_ style. Additionally, all query manipulation is handled by the _Guzzle_ PSR7 package. The built-in `parse_str` function cannot properly handle query names containing a dot character, as it converts them to underscores:

```php
$query = [];
parse_str('foo.bar=baz', $query);

var_dump($query);

// array(1) {
//   ["foo_bar"]=>
//   string(3) "baz"
// }
```

Closes #37.