### PR TITLE
Validate pattern for string property

### DIFF
--- a/src/OpenApi/SchemaReader.php
+++ b/src/OpenApi/SchemaReader.php
@@ -87,6 +87,12 @@ final class SchemaReader
             );
         }
 
+        if ($schema->pattern && ! preg_match("/{$schema->pattern}/", $value)) {
+            throw new InvalidArgumentException(sprintf(
+                'The value must match the pattern "%s"', $schema->pattern
+            ));
+        }
+
         return $value;
     }
 

--- a/tests/OpenApi/SchemaReaderTest.php
+++ b/tests/OpenApi/SchemaReaderTest.php
@@ -84,6 +84,16 @@ final class SchemaReaderTest extends TestCase
         $reader->getStringProperty($schema, 'invalid', 'value');
     }
 
+    public function test_get_string_property_pattern(): void
+    {
+        $schema = Schema::make(['pattern' => '^\\d{4}$']);
+        $reader = new SchemaReader();
+        $this->assertSame('2024', $reader->getStringProperty($schema, '2024', 'value'));
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The value must match the pattern "^\\d{4}$"');
+        $reader->getStringProperty($schema, '202412', 'value');
+    }
+
     public function test_get_integer_property_int32(): void
     {
         $reader = new SchemaReader();


### PR DESCRIPTION
The PR brings support for validating the string with _pattern_ field schema, if provided.

Closes #43.