### PR TITLE
Update vendor name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "dew/acs-sdk-php",
+    "name": "dewcloud/acs-sdk-php",
     "description": "Unofficial Alibaba Cloud PHP SDK.",
     "type": "library",
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "dewcloud/acs-sdk-php",
+    "name": "dew-serverless/acs-sdk-php",
     "description": "Unofficial Alibaba Cloud PHP SDK.",
     "type": "library",
     "require": {


### PR DESCRIPTION
Since the vendor name _dew_ is already taken on Packagist.org, we’ve decided to use _dew-serverless_ instead.