### PR TITLE
SLS: respect PutLogs schema

### DIFF
--- a/src/Sls/ManagesLogs.php
+++ b/src/Sls/ManagesLogs.php
@@ -19,7 +19,7 @@ trait ManagesLogs
     public function putLogsAsync(array $arguments): Promise
     {
         // @phpstan-ignore argument.type
-        $group = Protobuf::toLogGroup($arguments);
+        $group = Protobuf::toLogGroup($arguments['body'] ?? []);
 
         $request = $this->newRequest('POST')
             ->withHeader('Content-Type', 'application/x-protobuf')

--- a/src/Sls/Protobuf.php
+++ b/src/Sls/Protobuf.php
@@ -11,6 +11,10 @@ use Dew\Acs\Sls\Messages\LogTag;
 use InvalidArgumentException;
 
 /**
+ * @phpstan-type TLogTag array{
+ *   Key: string,
+ *   Value: string
+ * }
  * @phpstan-type TLogContent array{
  *   Key: string,
  *   Value: string
@@ -23,7 +27,7 @@ use InvalidArgumentException;
  * @phpstan-type TLogGroup array{
  *   Topic?: string,
  *   Source?: string,
- *   LogTags?: array<string, string>,
+ *   LogTags?: TLogTag[],
  *   Logs: TLogItem[],
  *   MachineUuid?: string,
  * }
@@ -48,10 +52,8 @@ final class Protobuf
         if (isset($group['LogTags'])) {
             $tags = [];
 
-            foreach ($group['LogTags'] as $key => $value) {
-                $tags[] = (new LogTag())
-                    ->setKey($key)
-                    ->setValue($value);
+            foreach ($group['LogTags'] as $tag) {
+                $tags[] = static::toLogTag($tag);
             }
 
             $message->setTags($tags);
@@ -122,5 +124,27 @@ final class Protobuf
         return (new LogContent())
             ->setKey($content['Key'])
             ->setValue($content['Value']);
+    }
+
+    /**
+     * @param  TLogTag  $tag
+     */
+    public static function toLogTag(array $tag): LogTag
+    {
+        if (! isset($tag['Key'])) {
+            throw new InvalidArgumentException(
+                'The log tag should have a "Key" field.'
+            );
+        }
+
+        if (! isset($tag['Value'])) {
+            throw new InvalidArgumentException(
+                'The log tag should have a "Value" field.'
+            );
+        }
+
+        return (new LogTag())
+            ->setKey($tag['Key'])
+            ->setValue($tag['Value']);
     }
 }

--- a/tests/Sls/ProtobufTest.php
+++ b/tests/Sls/ProtobufTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dew\Acs\Tests\Sls;
+
+use Dew\Acs\Sls\Messages\Log;
+use Dew\Acs\Sls\Messages\LogContent;
+use Dew\Acs\Sls\Messages\LogGroup;
+use Dew\Acs\Sls\Protobuf;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Protobuf::class)]
+final class ProtobufTest extends TestCase
+{
+    public function test_to_log_content(): void
+    {
+        $message = Protobuf::toLogContent(['Key' => 'foo', 'Value' => 'bar']);
+        $this->assertInstanceOf(LogContent::class, $message);
+        $this->assertSame('foo', $message->getKey());
+        $this->assertSame('bar', $message->getValue());
+    }
+
+    public function test_to_log_content_missing_key(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The log content should have a "Key" field.');
+        Protobuf::toLogContent(['Value' => 'foo']);
+    }
+
+    public function test_to_log_content_missing_value(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The log content should have a "Value" field.');
+        Protobuf::toLogContent(['Key' => 'foo']);
+    }
+
+    public function test_to_log_item(): void
+    {
+        $now = time();
+        $message = Protobuf::toLogItem([
+            'Time' => $now,
+            'Contents' => [
+                ['Key' => 'key1', 'Value' => 'value1'],
+                ['Key' => 'key2', 'Value' => 'value2'],
+            ],
+        ]);
+        $this->assertInstanceOf(Log::class, $message);
+        $this->assertSame($now, $message->getTime());
+        $this->assertCount(2, $message->getContents());
+    }
+
+    public function test_to_log_item_time_ns(): void
+    {
+        $message = Protobuf::toLogItem([
+            'Time' => time(),
+            'Contents' => [['Key' => 'foo', 'Value' => 'bar']],
+            'TimeNs' => 123456789,
+        ]);
+        $this->assertInstanceOf(Log::class, $message);
+        $this->assertSame(123456789, $message->getTimeNs());
+    }
+
+    public function test_to_log_group(): void
+    {
+        $message = Protobuf::toLogGroup([
+            'Logs' => [[
+                'Time' => time(),
+                'Contents' => [['Key' => 'foo', 'Value' => 'bar']],
+            ]],
+        ]);
+        $this->assertInstanceOf(LogGroup::class, $message);
+        $this->assertCount(1, $message->getLogs());
+    }
+
+    public function test_to_log_group_topic(): void
+    {
+        $message = Protobuf::toLogGroup([
+            'Topic' => '__test',
+            'Logs' => [[
+                'Time' => time(),
+                'Contents' => [['Key' => 'foo', 'Value' => 'bar']],
+            ]],
+        ]);
+        $this->assertInstanceOf(LogGroup::class, $message);
+        $this->assertSame('__test', $message->getTopic());
+    }
+
+    public function test_to_log_group_source(): void
+    {
+        $message = Protobuf::toLogGroup([
+            'Source' => '__test',
+            'Logs' => [[
+                'Time' => time(),
+                'Contents' => [['Key' => 'foo', 'Value' => 'bar']],
+            ]],
+        ]);
+        $this->assertInstanceOf(LogGroup::class, $message);
+        $this->assertSame('__test', $message->getSource());
+    }
+
+    public function test_to_log_group_tags(): void
+    {
+        $message = Protobuf::toLogGroup([
+            'LogTags' => [
+                ['Key' => 'foo', 'Value' => 'bar'],
+            ],
+            'Logs' => [[
+                'Time' => time(),
+                'Contents' => [['Key' => 'status', 'Value' => '0']],
+            ]],
+        ]);
+        $this->assertInstanceOf(LogGroup::class, $message);
+        $this->assertCount(1, $message->getTags());
+    }
+
+    public function test_to_log_group_machine_uuid(): void
+    {
+        $message = Protobuf::toLogGroup([
+            'Logs' => [[
+                'Time' => time(),
+                'Contents' => [['Key' => 'status', 'Value' => '0']],
+            ]],
+            'MachineUuid' => '__test',
+        ]);
+        $this->assertInstanceOf(LogGroup::class, $message);
+        $this->assertSame('__test', $message->getMachineUuid());
+    }
+
+    public function test_to_log_tag(): void
+    {
+        $message = Protobuf::toLogTag(['Key' => 'foo', 'Value' => 'bar']);
+        $this->assertSame('foo', $message->getKey());
+        $this->assertSame('bar', $message->getValue());
+    }
+
+    public function test_to_log_tag_missing_key(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The log tag should have a "Key" field.');
+        Protobuf::toLogTag(['Value' => 'foo']);
+    }
+
+    public function test_to_log_tag_missing_value(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The log tag should have a "Value" field.');
+        Protobuf::toLogTag(['Key' => 'foo']);
+    }
+}

--- a/tests/Sls/SlsClientTest.php
+++ b/tests/Sls/SlsClientTest.php
@@ -22,11 +22,7 @@ final class SlsClientTest extends TestCase
     {
         $mock = new Client();
         $client = $this->makeClient(['http_client' => $mock]);
-        $client->putLogs([
-            'project' => 'testing',
-            'logstore' => 'default',
-            'logs' => [['time' => time(), 'contents' => ['message' => 'foo']]],
-        ]);
+        $client->putLogs(['project' => 'testing', 'logstore' => 'default']);
         $this->assertSame('/logstores/default/shards/lb', $mock->getLastRequest()->getUri()->getPath());
     }
 
@@ -37,7 +33,6 @@ final class SlsClientTest extends TestCase
         $client->putLogs([
             'project' => 'testing',
             'logstore' => 'default',
-            'logs' => [['time' => time(), 'contents' => ['message' => 'foo']]],
             'hash' => '00000000000000000000000000000000',
         ]);
         $uri = $mock->getLastRequest()->getUri();


### PR DESCRIPTION
This PR updates the data structure for the _SLS_ `PutLogs` API to align with the official API docs and includes test cases for validation.

While the API schema was recently added to the documentation, we are not building directly on it due to the following reasons:

1. The schema’s data compression options are incomplete, supporting only _lz4_, which is not functional. More importantly, I prefer not to implement a workaround.
2. Log data needs to be encoded in _Protobuf_ before being appended to the HTTP request body. Currently, we lack a mechanism to handle this encoding, so we will monitor the situation to see if additional APIs require similar data mutation handling.