### PR TITLE
Retrieve the underlying value from the backed enum when resolving the schema value

### DIFF
--- a/src/OpenApi/SchemaReader.php
+++ b/src/OpenApi/SchemaReader.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Dew\Acs\OpenApi;
 
+use BackedEnum;
 use Closure;
 use InvalidArgumentException;
 use RuntimeException;
@@ -28,6 +29,10 @@ final class SchemaReader
 
         if (! method_exists($this, $method)) {
             throw new RuntimeException("Unsupported data type {$schema->type}.");
+        }
+
+        if ($value instanceof BackedEnum) {
+            $value = $value->value;
         }
 
         $this->validateValueType($schema->type, $value, $attribute);

--- a/tests/OpenApi/SchemaReaderTest.php
+++ b/tests/OpenApi/SchemaReaderTest.php
@@ -394,6 +394,25 @@ final class SchemaReaderTest extends TestCase
         $this->assertSame(['value' => 1024], $reader->getProperty($schema, ['value' => 1024], 'value'));
     }
 
+    public function test_get_property_enum(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The value must be a string.');
+        $reader = new SchemaReader();
+        $schema = Schema::make(['type' => 'string']);
+        $reader->getProperty($schema, StubEnum::Foo, 'value');
+    }
+
+    public function test_get_property_backed_enum(): void
+    {
+        $reader = new SchemaReader();
+        $schema = Schema::make(['type' => 'string']);
+        $this->assertSame('bar', $reader->getProperty($schema, StubStringEnum::Foo, 'value'));
+
+        $schema = Schema::make(['type' => 'integer']);
+        $this->assertSame(0, $reader->getProperty($schema, StubIntEnum::Zero, 'value'));
+    }
+
     /**
      * @param  TSchema  $schema
      */
@@ -484,4 +503,19 @@ final class SchemaReaderTest extends TestCase
         $reader = new SchemaReader();
         $reader->{$method}($schema, $value, 'value');
     }
+}
+
+enum StubEnum
+{
+    case Foo;
+}
+
+enum StubStringEnum: string
+{
+    case Foo = 'bar';
+}
+
+enum StubIntEnum: int
+{
+    case Zero = 0;
 }


### PR DESCRIPTION
Enums are a useful technique for keeping code clean and maintainable. Suppose we have a schema structure that accepts a string value indicating a user's role in an API endpoint:

```php
enum Role: string
{
    case Admin = 'admin';
    case User = 'user';
}

$schema = Schema::make([
    'type' => 'object',
    'properties' => [
        'role' => [
            'type' => 'string',
        ],
    ],
]);
```

To ensure proper value validation and typing for the schema, we currently pass the enum value explicitly:

```php
$reader->getProperty($schema, [
    'role' => Role::User->value,
], 'value');
```

With the changes introduced in this Pull Request, we can simplify the syntax by passing the enum directly, reducing keystrokes and making the code cleaner:

```php
$reader->getProperty($schema, [
    'role' => Role::User,
], 'value');
```