### PR TITLE
Encode array value to JSON string when schema misses style specification

### DIFF
--- a/src/OpenApi/ROAStyleBuilder.php
+++ b/src/OpenApi/ROAStyleBuilder.php
@@ -255,7 +255,11 @@ final readonly class ROAStyleBuilder implements ApiDataBuilder
      */
     private function toStringValue(Parameter $parameter, mixed $value): string
     {
-        $value = is_scalar($value) ? (string) $value : $value;
+        $value = match (true) {
+            is_scalar($value) => (string) $value,
+            is_array($value) => (new JsonEncoder())->encode($value),
+            default => $value,
+        };
 
         if (! is_string($value)) {
             throw new InvalidArgumentException(

--- a/tests/OpenApi/ROAStyleBuilderTest.php
+++ b/tests/OpenApi/ROAStyleBuilderTest.php
@@ -164,30 +164,6 @@ final class ROAStyleBuilderTest extends TestCase
         $this->assertSame(['x-test-*' => 'foo'], $data->headers);
     }
 
-    public function test_headers_resolution_wildcard_invalid(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The header value "x-test-invalid" must be a string.');
-        $docs = $this->makeApiDocs();
-        $api = $this->makeApi([
-            'parameters' => [[
-                'name' => 'x-test-*',
-                'in' => 'header',
-                'schema' => [
-                    'type' => 'object',
-                    'properties' => [
-                        'invalid' => [
-                            'type' => 'object',
-                            'properties' => [],
-                        ],
-                    ],
-                ],
-            ]],
-        ]);
-        $builder = new ROAStyleBuilder($docs, $api);
-        $builder->build(['x-test-*' => ['invalid' => []]]);
-    }
-
     public function test_headers_resolution_body_json_style(): void
     {
         $docs = $this->makeApiDocs();
@@ -387,6 +363,28 @@ final class ROAStyleBuilderTest extends TestCase
         <value>foo</value>
 
         XML, $data->body);
+    }
+
+    public function test_parameter_missing_style_array_should_encode_to_json_string(): void
+    {
+        $docs = $this->makeApiDocs();
+        $api = $this->makeApi([
+            'parameters' => [[
+                'name' => 'body',
+                'in' => 'body',
+                'schema' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'name' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ]],
+        ]);
+        $builder = new ROAStyleBuilder($docs, $api);
+        $data = $builder->build(['body' => ['name' => 'Li Zhineng']]);
+        $this->assertSame(json_encode(['name' => 'Li Zhineng']), $data->body);
     }
 
     public function test_parameter_required(): void


### PR DESCRIPTION
Some schema definitions for body location parameters are missing a style specification, such as "json" or "xml." Since the HTTP body needs to be encoded as a string, instead of throwing an exception, we attempt to encode the value as a JSON string when the style indication is absent.