### PR TITLE
Respect product exception when something goes wrong

### DIFF
--- a/src/AcsException.php
+++ b/src/AcsException.php
@@ -26,7 +26,7 @@ class AcsException extends Exception
      */
     protected ?Result $result = null;
 
-    public function __construct(string $message, int|string $code)
+    final public function __construct(string $message, int|string $code)
     {
         $this->message = $message;
         $this->code = $code;
@@ -35,9 +35,9 @@ class AcsException extends Exception
     /**
      * @param  \Dew\Acs\Result<TError>  $result
      */
-    public static function makeFromResult(Result $result): self
+    public static function makeFromResult(Result $result): static
     {
-        $e = new self(
+        $e = new static(
             $result->get('Message', 'Could not communicate with Alibaba Cloud.'),
             $result->get('Code', 0)
         );

--- a/tests/Fixtures/StubException.php
+++ b/tests/Fixtures/StubException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dew\Acs\Tests\Fixtures;
+
+use Dew\Acs\AcsException;
+
+final class StubException extends AcsException
+{
+    //
+}

--- a/tests/ResultProviderTest.php
+++ b/tests/ResultProviderTest.php
@@ -7,6 +7,7 @@ namespace Dew\Acs\Tests;
 use Dew\Acs\OpenApi\Api;
 use Dew\Acs\OpenApi\ApiDocs;
 use Dew\Acs\ResultProvider;
+use Dew\Acs\Tests\Fixtures\StubException;
 use Nyholm\Psr7\Response;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -71,6 +72,18 @@ final class ResultProviderTest extends TestCase
         $provider = new ResultProvider($this->makeApiDocs());
         $result = $provider->make($response, $api);
         $this->assertSame(['value' => 10], $result->getDecodedData());
+    }
+
+    public function test_make_exception(): void
+    {
+        $this->expectException(StubException::class);
+        $this->expectExceptionMessage('Something went wrong!');
+        $docs = $this->makeApiDocs();
+        $api = $this->makeApi();
+        $error = ['Code' => 'InternalError', 'Message' => 'Something went wrong!'];
+        $response = new Response(500, ['Content-Type' => 'application/json'], json_encode($error));
+        $provider = new ResultProvider($this->makeApiDocs(), StubException::class);
+        $provider->make($response, $api);
     }
 
     private function makeApiDocs(): ApiDocs


### PR DESCRIPTION
Use `static` instead of `self` to create exception instances, ensuring that the correct exception class is thrown. For instance, `ABCException`, to be thrown for failed requests from the ABC product, rather than the global `AcsException`.