### PR TITLE
Trim the endpoint

### DIFF
--- a/src/OpenApi/ApiDocs.php
+++ b/src/OpenApi/ApiDocs.php
@@ -67,7 +67,7 @@ final readonly class ApiDocs
     {
         foreach ($this->endpoints as $endpoint) {
             if ($endpoint['regionId'] === $regionId) {
-                return $endpoint['endpoint'];
+                return trim($endpoint['endpoint']);
             }
         }
 

--- a/tests/OpenApi/ApiDocsTest.php
+++ b/tests/OpenApi/ApiDocsTest.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Dew\Acs\Tests\OpenApi;
 
 use Dew\Acs\OpenApi\ApiDocs;
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
 
 #[CoversClass(ApiDocs::class)]
 final class ApiDocsTest extends TestCase

--- a/tests/OpenApi/ApiDocsTest.php
+++ b/tests/OpenApi/ApiDocsTest.php
@@ -8,6 +8,7 @@ use Dew\Acs\OpenApi\ApiDocs;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
+use InvalidArgumentException;
 
 #[CoversClass(ApiDocs::class)]
 final class ApiDocsTest extends TestCase
@@ -32,5 +33,62 @@ final class ApiDocsTest extends TestCase
             'endpoints' => [],
         ]);
         $this->assertSame($expected, $doc->getNamespace());
+    }
+
+    public function test_get_endpoint_resolves_the_endpoint_from_region(): void
+    {
+        $docs = ApiDocs::make([
+            'info' => [
+                'style' => 'RPC',
+                'product' => 'Testing',
+                'version' => '2024-01-01',
+            ],
+            'directories' => [],
+            'components' => [],
+            'apis' => [],
+            'endpoints' => [
+                ['regionId' => 'cn-somewhere', 'endpoint' => 'example.com'],
+            ],
+        ]);
+        $this->assertSame('example.com', $docs->getEndpoint('cn-somewhere'));
+    }
+
+    #[TestWith(['example.com '])]
+    #[TestWith([' example.com'])]
+    #[TestWith([' example.com '])]
+    #[TestWith(["example.com\t"])]
+    public function test_get_endpoint_trims_the_endpoint(string $endpoint): void
+    {
+        $docs = ApiDocs::make([
+            'info' => [
+                'style' => 'RPC',
+                'product' => 'Testing',
+                'version' => '2024-01-01',
+            ],
+            'directories' => [],
+            'components' => [],
+            'apis' => [],
+            'endpoints' => [
+                ['regionId' => 'cn-somewhere', 'endpoint' => $endpoint],
+            ],
+        ]);
+        $this->assertSame('example.com', $docs->getEndpoint('cn-somewhere'));
+    }
+
+    public function test_get_endpoint_endpoint_does_not_exist(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Could not find the endpoint for region cn-somewhere.');
+        ApiDocs::make([
+            'info' => [
+                'style' => 'RPC',
+                'product' => 'Testing',
+                'version' => '2024-01-01',
+            ],
+            'directories' => [],
+            'components' => [],
+            'apis' => [],
+            'endpoints' => [],
+        ])->getEndpoint('cn-somewhere');
     }
 }


### PR DESCRIPTION
I discovered that there is a tab suffix on an endpoint while reviewing the metadata changes #70. To ensure proper functionality, we need to trim the endpoint before composing the HTTP request.