### PR TITLE
Compatible when object definition is missing

### DIFF
--- a/src/OpenApi/SchemaReader.php
+++ b/src/OpenApi/SchemaReader.php
@@ -184,7 +184,10 @@ final class SchemaReader
             );
         }
 
-        throw new RuntimeException('The properties could not be found in the schema.');
+        // If the object definition is missing from the parameter to fulfill
+        // the API request, we let the user take full control of the data
+        // that's sent over the wire instead of throwing the exception.
+        return $value;
     }
 
     /**

--- a/tests/OpenApi/SchemaReaderTest.php
+++ b/tests/OpenApi/SchemaReaderTest.php
@@ -255,6 +255,14 @@ final class SchemaReaderTest extends TestCase
         $this->assertSame(['value' => 'foo'], $reader->getObjectProperty($schema, ['value' => 'foo'], 'value'));
     }
 
+    public function test_get_object_without_definition(): void
+    {
+        $reader = new SchemaReader();
+        $schema = Schema::make([]);
+        $value = $reader->getObjectProperty($schema, ['value' => 'foo'], 'value');
+        $this->assertSame(['value' => 'foo'], $value);
+    }
+
     public function test_get_array_property(): void
     {
         $reader = new SchemaReader();


### PR DESCRIPTION
There are some object parameters that lack a concrete property definition in metadata update #73, this PR helps get around that limitation and give users full control over the data that's sent over the wire.