### PR TITLE
Fix PHP 8.4 deprecation warning caused by nullable type declaration

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -30,5 +30,9 @@ return (new PhpCsFixer\Config())
         'phpdoc_separation' => [
             'skip_unlisted_annotations' => true,
         ],
+        'nullable_type_declaration' => [
+            'syntax' => 'question_mark',
+        ],
+        'nullable_type_declaration_for_default_null_value' => true,
     ])
     ->setFinder($finder);

--- a/src/Signatures/V3Signature.php
+++ b/src/Signatures/V3Signature.php
@@ -145,7 +145,7 @@ final class V3Signature implements SignsRequest, NeedsApiContext
     /**
      * @param  string[]|null  $headers
      */
-    public function getCanonicalHeaders(RequestInterface $request, array $headers = null): string
+    public function getCanonicalHeaders(RequestInterface $request, ?array $headers = null): string
     {
         $headers ??= $this->getSignedHeaders($request);
 


### PR DESCRIPTION
Closes #78.