### PR TITLE
MNS: Send and receive queue messages

### DIFF
--- a/src/AcsException.php
+++ b/src/AcsException.php
@@ -60,9 +60,11 @@ class AcsException extends Exception
     }
 
     /**
+     * Get the underlying result.
+     *
      * @return \Dew\Acs\Result<array<mixed>>|null
      */
-    public function getResult(): ?Result
+    public function getResult()
     {
         return $this->result;
     }

--- a/src/AcsException.php
+++ b/src/AcsException.php
@@ -7,22 +7,25 @@ namespace Dew\Acs;
 use Exception;
 use Psr\Http\Message\ResponseInterface;
 
-/**
- * @phpstan-type TError array{
- *   Code: string,
- *   Message: string,
- *   RequestId: string
- * }
- */
 class AcsException extends Exception
 {
+    /**
+     * The message field in the error response.
+     */
+    public const ERROR_MESSAGE = 'Message';
+
+    /**
+     * The code field in the error response.
+     */
+    public const ERROR_CODE = 'Code';
+
     /**
      * @var int|string
      */
     protected $code;
 
     /**
-     * @var \Dew\Acs\Result<TError>|null
+     * @var \Dew\Acs\Result<array<mixed>>|null
      */
     protected ?Result $result = null;
 
@@ -33,20 +36,21 @@ class AcsException extends Exception
     }
 
     /**
-     * @param  \Dew\Acs\Result<TError>  $result
+     * @param  \Dew\Acs\Result<array<mixed>>  $result
      */
     public static function makeFromResult(Result $result): static
     {
-        $e = new static(
-            $result->get('Message', 'Could not communicate with Alibaba Cloud.'),
-            $result->get('Code', 0)
-        );
+        /** @var string */
+        $message = $result->get(static::ERROR_MESSAGE, 'Could not communicate with Alibaba Cloud.');
 
-        return $e->setResult($result);
+        /** @var string|int */
+        $code = $result->get(static::ERROR_CODE, 0);
+
+        return (new static($message, $code))->setResult($result);
     }
 
     /**
-     * @param  \Dew\Acs\Result<TError>  $result
+     * @param  \Dew\Acs\Result<array<mixed>>  $result
      */
     public function setResult(Result $result): static
     {
@@ -56,7 +60,7 @@ class AcsException extends Exception
     }
 
     /**
-     * @return \Dew\Acs\Result<TError>|null
+     * @return \Dew\Acs\Result<array<mixed>>|null
      */
     public function getResult(): ?Result
     {

--- a/src/MnsOpen/MnsSignature.php
+++ b/src/MnsOpen/MnsSignature.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dew\Acs\MnsOpen;
+
+use DateTimeInterface;
+use Dew\Acs\ConfigChecker;
+use Dew\Acs\Signatures\SignsRequest;
+use Override;
+use Psr\Http\Message\RequestInterface;
+use SensitiveParameter;
+
+final readonly class MnsSignature implements SignsRequest
+{
+    /**
+     * The config validator.
+     */
+    private ConfigChecker $configChecker;
+
+    /**
+     * Create a new MNS signature instance.
+     */
+    public function __construct()
+    {
+        $this->configChecker = new ConfigChecker();
+    }
+
+    #[Override]
+    public function signRequest(RequestInterface $request, array $config): RequestInterface
+    {
+        $this->configChecker->ensureCredentialsExist($config);
+
+        $request = $request
+            ->withHeader('date', gmdate(DateTimeInterface::RFC7231))
+            ->withHeader('x-mns-version', '2015-06-06');
+
+        return $request->withHeader('Authorization', sprintf('MNS %s:%s',
+            $config['credentials']['key'],
+            $this->signature($request, $config['credentials']['secret'])
+        ));
+    }
+
+    /**
+     * Calculate the signature for the request.
+     */
+    public function signature(RequestInterface $request, #[SensitiveParameter] string $key): string
+    {
+        return base64_encode(hash_hmac(
+            'sha1', $this->stringToSign($request), $key, binary: true
+        ));
+    }
+
+    /**
+     * Create signing data from the HTTP request.
+     */
+    public function stringToSign(RequestInterface $request): string
+    {
+        return implode("\n", [
+            $request->getMethod(),
+            $request->getHeaderLine('content-md5'),
+            $request->getHeaderLine('content-type'),
+            $request->getHeaderLine('date'),
+            $this->canonicalizedHeaders($request),
+            $this->canonicalizedResource($request),
+        ]);
+    }
+
+    /**
+     * Build canonicalized header string.
+     */
+    public function canonicalizedHeaders(RequestInterface $request): string
+    {
+        $headers = array_change_key_case($request->getHeaders(), CASE_LOWER);
+
+        ksort($headers);
+
+        $result = [];
+
+        foreach ($headers as $name => $values) {
+            if ($this->isMnsHeader($name)) {
+                $result[] = $name.':'.$values[0];
+            }
+        }
+
+        return implode("\n", $result);
+    }
+
+    /**
+     * Build canonicalized resource string.
+     */
+    public function canonicalizedResource(RequestInterface $request): string
+    {
+        $path = $request->getUri()->getPath();
+        $query = $request->getUri()->getQuery();
+
+        if ($query === '') {
+            return $path;
+        }
+
+        return $path.'?'.$query;
+    }
+
+    /**
+     * Determine if the header is a MNS custom header.
+     */
+    public function isMnsHeader(string $header): bool
+    {
+        return str_starts_with(strtolower($header), 'x-mns-');
+    }
+}

--- a/src/MnsOpen/Models/ChangeVisibility.php
+++ b/src/MnsOpen/Models/ChangeVisibility.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dew\Acs\MnsOpen\Models;
+
+/**
+ * @phpstan-type TChangeVisibility array{
+ *   ReceiptHandle: string,
+ *   NextVisibleTime: string
+ * }
+ */
+final readonly class ChangeVisibility
+{
+    /**
+     * Create a new model instance.
+     */
+    public function __construct(
+        public string $receiptHandle,
+        public int $nextVisibleTime
+    ) {
+        //
+    }
+
+    /**
+     * Create a model from the data payload.
+     *
+     * @param  TChangeVisibility  $data
+     */
+    public static function make(array $data): static
+    {
+        return new static(
+            $data['ReceiptHandle'],
+            (int) $data['NextVisibleTime']
+        );
+    }
+}

--- a/src/MnsOpen/Models/PeekMessage.php
+++ b/src/MnsOpen/Models/PeekMessage.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dew\Acs\MnsOpen\Models;
+
+/**
+ * @phpstan-type TPeekMessage array{
+ *   MessageId: string,
+ *   MessageBodyMD5: string,
+ *   MessageBody: string,
+ *   EnqueueTime: int,
+ *   FirstDequeueTime: int,
+ *   DequeueCount: int,
+ *   Priority: int
+ * }
+ */
+final readonly class PeekMessage
+{
+    /**
+     * Create a new model instance.
+     */
+    public function __construct(
+        public string $messageId,
+        public string $messageBodyMd5,
+        public string $messageBody,
+        public int $enqueueTime,
+        public int $firstDequeueTime,
+        public int $dequeueCount,
+        public int $priority
+    ) {
+        //
+    }
+
+    /**
+     * Create a model from the data payload.
+     *
+     * @param  TPeekMessage  $data
+     */
+    public static function make(array $data): static
+    {
+        return new static(
+            $data['MessageId'],
+            $data['MessageBodyMD5'],
+            $data['MessageBody'],
+            (int) $data['EnqueueTime'],
+            (int) $data['FirstDequeueTime'],
+            (int) $data['DequeueCount'],
+            (int) $data['Priority']
+        );
+    }
+}

--- a/src/MnsOpen/Models/ReceiveMessage.php
+++ b/src/MnsOpen/Models/ReceiveMessage.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dew\Acs\MnsOpen\Models;
+
+/**
+ * @phpstan-type TReceiveMessage array{
+ *   MessageId: string,
+ *   ReceiptHandle: string,
+ *   MessageBodyMD5: string,
+ *   MessageBody: string,
+ *   EnqueueTime: string,
+ *   NextVisibleTime: string,
+ *   FirstDequeueTime: string,
+ *   DequeueCount: string,
+ *   Priority: string
+ * }
+ */
+final readonly class ReceiveMessage
+{
+    /**
+     * Create a new model instance.
+     */
+    public function __construct(
+        public string $messageId,
+        public string $receiptHandle,
+        public string $messageBodyMd5,
+        public string $messageBody,
+        public int $enqueueTime,
+        public int $nextVisibleTime,
+        public int $firstDequeueTime,
+        public int $dequeueCount,
+        public int $priority
+    ) {
+        //
+    }
+
+    /**
+     * Create a model from the data payload.
+     *
+     * @param  TReceiveMessage  $data
+     */
+    public static function make(array $data): static
+    {
+        return new static(
+            $data['MessageId'],
+            $data['ReceiptHandle'],
+            $data['MessageBodyMD5'],
+            $data['MessageBody'],
+            (int) $data['EnqueueTime'],
+            (int) $data['NextVisibleTime'],
+            (int) $data['FirstDequeueTime'],
+            (int) $data['DequeueCount'],
+            (int) $data['Priority']
+        );
+    }
+}

--- a/src/MnsOpen/Models/SendMessage.php
+++ b/src/MnsOpen/Models/SendMessage.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dew\Acs\MnsOpen\Models;
+
+/**
+ * @phpstan-type TSendMessage array{MessageId: string, MessageBodyMD5: string}
+ */
+final readonly class SendMessage
+{
+    /**
+     * Create a new model instance.
+     */
+    public function __construct(
+        public string $messageId,
+        public string $messageBodyMd5
+    ) {
+        //
+    }
+
+    /**
+     * Create a model from the data payload.
+     *
+     * @param  TSendMessage  $data
+     */
+    public static function make(array $data): static
+    {
+        return new static(
+            $data['MessageId'],
+            $data['MessageBodyMD5']
+        );
+    }
+}

--- a/src/MnsOpen/QueueClient.php
+++ b/src/MnsOpen/QueueClient.php
@@ -295,13 +295,7 @@ final readonly class QueueClient
                     ->setResponse($response->getPsrResponse());
 
                 if ($response->isError()) {
-                    /** @var string */
-                    $message = $result->get('Error.Message', 'Could not communicate with Alibaba Cloud.');
-
-                    /** @var string|int */
-                    $code = $result->get('Error.Code', 0);
-
-                    throw (new QueueException($message, $code))->setResult($result);
+                    throw QueueException::makeFromResult($result);
                 }
 
                 return $result;

--- a/src/MnsOpen/QueueClient.php
+++ b/src/MnsOpen/QueueClient.php
@@ -261,6 +261,16 @@ final readonly class QueueClient
     }
 
     /**
+     * Execute an API action.
+     *
+     * @param  array<int, mixed>  $arguments
+     */
+    private function execute(string $action, array $arguments = []): mixed
+    {
+        return $this->executeAsync($action, $arguments)->wait();
+    }
+
+    /**
      * Send an HTTP request asynchronously.
      *
      * @param  array<string, mixed>  $data
@@ -333,7 +343,7 @@ final readonly class QueueClient
     public function __call(string $method, array $arguments = []): mixed
     {
         if (method_exists($this, $method.'Async')) {
-            return $this->executeAsync($method, $arguments)->wait();
+            return $this->execute($method, $arguments);
         }
 
         throw new RuntimeException(sprintf('Call to undefined method %s::%s()', self::class, $method));

--- a/src/MnsOpen/QueueClient.php
+++ b/src/MnsOpen/QueueClient.php
@@ -1,0 +1,309 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dew\Acs\MnsOpen;
+
+use Dew\Acs\DataEncoder;
+use Dew\Acs\Plugins\SignRequest;
+use Dew\Acs\Result;
+use Dew\Acs\XmlEncoder;
+use GuzzleHttp\Psr7;
+use Http\Client\Common\PluginClient;
+use Http\Discovery\Psr17FactoryDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
+use Http\Promise\FulfilledPromise;
+use Http\Promise\Promise;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use RuntimeException;
+
+/**
+ * @phpstan-type TConfig array{
+ *   credentials: array{
+ *     key: string,
+ *     secret: string
+ *   },
+ *   endpoint: string,
+ *   http_client?: \Psr\Http\Client\ClientInterface
+ * }
+ * @phpstan-type TSendMessage array{
+ *   QueueName: string,
+ *   Message: array{
+ *     MessageBody: string,
+ *     DelaySeconds?: int
+ *   }
+ * }
+ * @phpstan-type TBatchSendMessage array{
+ *   QueueName: string,
+ *   Messages: array{
+ *     Message: array{
+ *       MessageBody: string,
+ *       DelaySeconds?: int
+ *     }[]
+ *   }
+ * }
+ * @phpstan-type TReceiveMessage array{QueueName: string, waitseconds?: int}
+ * @phpstan-type TBatchReceiveMessage array{
+ *   QueueName: string,
+ *   numOfMessages: int,
+ *   waitseconds?: int
+ * }
+ * @phpstan-type TDeleteMessage array{QueueName: string, ReceiptHandle: string}
+ * @phpstan-type TBatchDeleteMessage array{
+ *   QueueName: string,
+ *   ReceiptHandles: array{
+ *     ReceiptHandle: string[]
+ *   }
+ * }
+ * @phpstan-type TPeekMessage array{QueueName: string}
+ * @phpstan-type TBatchPeekMessage array{QueueName: string, numOfMessages: int}
+ * @phpstan-type TChangeMessageVisibility array{
+ *   QueueName: string,
+ *   ReceiptHandle: string,
+ *   VisibilityTimeout: int
+ * }
+ *
+ * @method \Dew\Acs\Result sendMessage(TSendMessage $arguments)
+ * @method \Dew\Acs\Result batchSendMessage(TBatchSendMessage $arguments)
+ * @method \Dew\Acs\Result receiveMessage(TReceiveMessage $arguments)
+ * @method \Dew\Acs\Result batchReceiveMessage(TBatchReceiveMessage $arguments)
+ * @method \Dew\Acs\Result deleteMessage(TDeleteMessage $arguments)
+ * @method \Dew\Acs\Result batchDeleteMessage(TBatchDeleteMessage $arguments)
+ * @method \Dew\Acs\Result peekMessage(TPeekMessage $arguments)
+ * @method \Dew\Acs\Result batchPeekMessage(TBatchPeekMessage $arguments)
+ * @method \Dew\Acs\Result changeMessageVisibility(TChangeMessageVisibility $arguments)
+ */
+final readonly class QueueClient
+{
+    /**
+     * The HTTP request factory.
+     */
+    private RequestFactoryInterface $requestFactory;
+
+    /**
+     * The stream factory.
+     */
+    private StreamFactoryInterface $streamFactory;
+
+    /**
+     * The HTTP client.
+     */
+    private ClientInterface $client;
+
+    /**
+     * The XML encoder.
+     */
+    private DataEncoder $encoder;
+
+    /**
+     * Create a new queue client instance.
+     *
+     * @param  TConfig  $config
+     */
+    public function __construct(
+        private array $config
+    ) {
+        $this->requestFactory = Psr17FactoryDiscovery::findRequestFactory();
+        $this->streamFactory = Psr17FactoryDiscovery::findStreamFactory();
+        $this->client = $config['http_client'] ?? Psr18ClientDiscovery::find();
+        $this->encoder = new XmlEncoder();
+    }
+
+    /**
+     * Send a message to queue.
+     *
+     * @param  TSendMessage  $arguments
+     */
+    public function sendMessageAsync(array $arguments): Promise
+    {
+        return $this->send('POST', sprintf('/queues/%s/messages', $arguments['QueueName']), [
+            'Message' => $arguments['Message'],
+        ]);
+    }
+
+    /**
+     * Send multiple messages to queue.
+     *
+     * @param  TBatchSendMessage  $arguments
+     */
+    public function batchSendMessageAsync(array $arguments): Promise
+    {
+        return $this->send(
+            'POST', sprintf('/queues/%s/messages', $arguments['QueueName']),
+            ['Messages' => $arguments['Messages']]
+        );
+    }
+
+    /**
+     * Get a message from queue.
+     *
+     * @param  TReceiveMessage  $arguments
+     */
+    public function receiveMessageAsync(array $arguments): Promise
+    {
+        $query = Psr7\Query::build(array_filter([
+            'waitseconds' => $arguments['waitseconds'] ?? null,
+        ]));
+
+        return $this->send('GET', sprintf('/queues/%s/messages%s',
+            $arguments['QueueName'],
+            $query === '' ? '' : '?'.$query
+        ));
+    }
+
+    /**
+     * Get multiple messages from queue.
+     *
+     * @param  TBatchReceiveMessage  $arguments
+     */
+    public function batchReceiveMessageAsync(array $arguments): Promise
+    {
+        $query = Psr7\Query::build(array_filter([
+            'numOfMessages' => $arguments['numOfMessages'],
+            'waitseconds' => $arguments['waitseconds'] ?? null,
+        ]));
+
+        return $this->send('GET', sprintf('/queues/%s/messages?%s',
+            $arguments['QueueName'], $query
+        ));
+    }
+
+    /**
+     * Delete a message from queue.
+     *
+     * @param  TDeleteMessage  $arguments
+     */
+    public function deleteMessageAsync(array $arguments): Promise
+    {
+        return $this->send('DELETE', sprintf('/queues/%s/messages?ReceiptHandle=%s',
+            $arguments['QueueName'], $arguments['ReceiptHandle']
+        ));
+    }
+
+    /**
+     * Delete multiple messages from queue.
+     *
+     * @param  TBatchDeleteMessage  $arguments
+     */
+    public function batchDeleteMessageAsync(array $arguments): Promise
+    {
+        return $this->send(
+            'DELETE', sprintf('/queues/%s/messages', $arguments['QueueName']), [
+                'ReceiptHandles' => $arguments['ReceiptHandles'],
+            ]
+        );
+    }
+
+    /**
+     * Peek a message from queue.
+     *
+     * @param  TPeekMessage  $arguments
+     */
+    public function peekMessageAsync(array $arguments): Promise
+    {
+        return $this->send('GET', sprintf('/queues/%s/messages?peekonly=true',
+            $arguments['QueueName']
+        ));
+    }
+
+    /**
+     * Peek multiple messages from queue.
+     *
+     * @param  TBatchPeekMessage  $arguments
+     */
+    public function batchPeekMessageAsync(array $arguments): Promise
+    {
+        return $this->send('GET', sprintf(
+            '/queues/%s/messages?peekonly=true&numOfMessages=%s',
+            $arguments['QueueName'], $arguments['numOfMessages']
+        ));
+    }
+
+    /**
+     * Update message next available time.
+     *
+     * @param  TChangeMessageVisibility  $arguments
+     */
+    public function changeMessageVisibilityAsync(array $arguments): Promise
+    {
+        return $this->send('PUT', sprintf(
+            '/queues/%s/messages?receiptHandle=%s&visibilityTimeout=%s',
+            $arguments['QueueName'], $arguments['ReceiptHandle'],
+            $arguments['VisibilityTimeout'],
+        ));
+    }
+
+    /**
+     * Execute an API action asynchronously.
+     *
+     * @param  array<int, mixed>  $arguments
+     */
+    private function executeAsync(string $action, array $arguments = []): Promise
+    {
+        return $this->{$action.'Async'}(...$arguments);
+    }
+
+    /**
+     * Send an HTTP request asynchronously.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    private function send(string $method, string $resource, array $data = []): Promise
+    {
+        $uri = new Psr7\Uri($resource);
+
+        $request = $this->requestFactory->createRequest($method, $this->config['endpoint']);
+        $request = $request->withUri($request->getUri()
+            ->withPath($uri->getPath())
+            ->withQuery($uri->getQuery())
+        );
+
+        if ($data !== []) {
+            $request = $request
+                ->withHeader('Content-Type', 'text/xml')
+                ->withBody($this->streamFactory->createStream($this->encoder->encode($data)));
+        }
+
+        return $this->handleResponse($this->client()->sendAsyncRequest($request));
+    }
+
+    /**
+     * Create a new client.
+     */
+    private function client(): PluginClient
+    {
+        return new PluginClient($this->client, [
+            SignRequest::withSignature(new MnsSignature(), $this->config),
+        ]);
+    }
+
+    /**
+     * Decode the XML document.
+     */
+    private function handleResponse(Promise $promise): Promise
+    {
+        return (new FulfilledPromise($promise))
+            ->then(function (Promise $promise): Result {
+                /** @var \Psr\Http\Message\ResponseInterface */
+                $response = $promise->wait();
+
+                return (new Result(
+                    $this->encoder->decode((string) $response->getBody())
+                ))->setResponse($response);
+            });
+    }
+
+    /**
+     * @param  array<int, mixed>  $arguments
+     */
+    public function __call(string $method, array $arguments = []): mixed
+    {
+        if (method_exists($this, $method.'Async')) {
+            return $this->executeAsync($method, $arguments)->wait();
+        }
+
+        throw new RuntimeException(sprintf('Call to undefined method %s::%s()', self::class, $method));
+    }
+}

--- a/src/MnsOpen/QueueException.php
+++ b/src/MnsOpen/QueueException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dew\Acs\MnsOpen;
+
+use Dew\Acs\AcsException;
+
+final class QueueException extends AcsException
+{
+    //
+}

--- a/src/MnsOpen/QueueException.php
+++ b/src/MnsOpen/QueueException.php
@@ -8,5 +8,13 @@ use Dew\Acs\AcsException;
 
 final class QueueException extends AcsException
 {
-    //
+    /**
+     * The message field in the error response.
+     */
+    public const ERROR_MESSAGE = 'Error.Message';
+
+    /**
+     * The code field in the error response.
+     */
+    public const ERROR_CODE = 'Error.Code';
 }

--- a/src/MnsOpen/QueueException.php
+++ b/src/MnsOpen/QueueException.php
@@ -5,7 +5,12 @@ declare(strict_types=1);
 namespace Dew\Acs\MnsOpen;
 
 use Dew\Acs\AcsException;
+use Dew\Acs\Result;
+use Override;
 
+/**
+ * @phpstan-type TErrorsError array{ErrorCode: string, ErrorMessage: string}
+ */
 final class QueueException extends AcsException
 {
     /**
@@ -17,4 +22,48 @@ final class QueueException extends AcsException
      * The code field in the error response.
      */
     public const ERROR_CODE = 'Error.Code';
+
+    #[Override]
+    public static function makeFromResult(Result $result): static
+    {
+        if (! $result->has('Errors.Error')) {
+            return parent::makeFromResult($result);
+        }
+
+        return static::makeFromMultipleErrors($result);
+    }
+
+    /**
+     * Create an exception from multiple errors.
+     *
+     * @param  \Dew\Acs\Result<array<mixed>>  $result
+     */
+    private static function makeFromMultipleErrors(Result $result): static
+    {
+        /** @var TErrorsError[]|TErrorsError */
+        $errors = $result->get('Errors.Error');
+
+        if (! is_array($errors)) {
+            return parent::makeFromResult($result);
+        }
+
+        /** @var TErrorsError[] */
+        $errors = array_is_list($errors) ? $errors : [$errors];
+
+        $total = count($errors);
+
+        if ($total === 0) {
+            return parent::makeFromResult($result);
+        }
+
+        ['ErrorMessage' => $message, 'ErrorCode' => $code] = $errors[0];
+
+        $message = match ($total) {
+            1 => $message,
+            2 => $message.' (and 1 other)',
+            default => $message.sprintf(' (and %d others)', $total - 1),
+        };
+
+        return (new static($message, $code))->setResult($result);
+    }
 }

--- a/src/MnsOpen/QueueException.php
+++ b/src/MnsOpen/QueueException.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Dew\Acs\MnsOpen;
 
 use Dew\Acs\AcsException;
+use Dew\Acs\MnsOpen\Results\MnsResult;
 use Dew\Acs\Result;
 use Override;
 
@@ -65,5 +66,16 @@ final class QueueException extends AcsException
         };
 
         return (new static($message, $code))->setResult($result);
+    }
+
+    /**
+     * Get the underlying result.
+     *
+     * @return \Dew\Acs\MnsOpen\Results\MnsResult|null
+     */
+    #[Override]
+    public function getResult()
+    {
+        return $this->result ? new MnsResult($this->result) : null;
     }
 }

--- a/src/MnsOpen/Results/BatchPeekMessageResult.php
+++ b/src/MnsOpen/Results/BatchPeekMessageResult.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dew\Acs\MnsOpen\Results;
+
+use Dew\Acs\MnsOpen\Models\PeekMessage;
+
+final class BatchPeekMessageResult extends MnsResult
+{
+    /**
+     * @return \Dew\Acs\MnsOpen\Models\PeekMessage[]
+     */
+    public function messages(): array
+    {
+        return $this->castInto('Messages.Message', PeekMessage::class);
+    }
+}

--- a/src/MnsOpen/Results/BatchReceiveMessageResult.php
+++ b/src/MnsOpen/Results/BatchReceiveMessageResult.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dew\Acs\MnsOpen\Results;
+
+use Dew\Acs\MnsOpen\Models\ReceiveMessage;
+
+final class BatchReceiveMessageResult extends MnsResult
+{
+    /**
+     * @return \Dew\Acs\MnsOpen\Models\ReceiveMessage[]
+     */
+    public function messages(): array
+    {
+        return $this->castInto('Messages.Message', ReceiveMessage::class);
+    }
+}

--- a/src/MnsOpen/Results/BatchSendMessageResult.php
+++ b/src/MnsOpen/Results/BatchSendMessageResult.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dew\Acs\MnsOpen\Results;
+
+use Dew\Acs\MnsOpen\Models\SendMessage;
+
+final class BatchSendMessageResult extends MnsResult
+{
+    /**
+     * @return \Dew\Acs\MnsOpen\Models\SendMessage[]
+     */
+    public function messages(): array
+    {
+        return $this->castInto('Messages.Message', SendMessage::class);
+    }
+}

--- a/src/MnsOpen/Results/ChangeMessageVisibilityResult.php
+++ b/src/MnsOpen/Results/ChangeMessageVisibilityResult.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dew\Acs\MnsOpen\Results;
+
+use Dew\Acs\MnsOpen\Models\ChangeVisibility;
+
+final class ChangeMessageVisibilityResult extends MnsResult
+{
+    public function changeVisibility(): ChangeVisibility
+    {
+        return ChangeVisibility::make($this->get('ChangeVisibility'));
+    }
+}

--- a/src/MnsOpen/Results/MnsResult.php
+++ b/src/MnsOpen/Results/MnsResult.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dew\Acs\MnsOpen\Results;
+
+use Dew\Acs\Result;
+
+/**
+ * @mixin \Dew\Acs\Result
+ */
+class MnsResult
+{
+    /**
+     * Create a new result instance.
+     *
+     * @param  \Dew\Acs\Result<array<mixed>>  $result
+     */
+    public function __construct(
+        protected Result $result
+    ) {
+        //
+    }
+
+    /**
+     * The request ID.
+     */
+    public function requestId(): ?string
+    {
+        $requestId = $this->getResponse()?->getHeaderLine('x-mns-request-id');
+
+        if ($requestId === null || $requestId === '') {
+            return null;
+        }
+
+        return $requestId;
+    }
+
+    /**
+     * The API version.
+     */
+    public function version(): ?string
+    {
+        $version = $this->getResponse()?->getHeaderLine('x-mns-version');
+
+        if ($version === null || $version === '') {
+            return null;
+        }
+
+        return $version;
+    }
+
+    /**
+     * Retrieve and cast data to a list array.
+     *
+     * @return array<int, mixed>|null
+     */
+    public function list(string $name): ?array
+    {
+        $result = $this->get($name);
+
+        if (! is_array($result)) {
+            return [$result];
+        }
+
+        return array_is_list($result) ? $result : [$result];
+    }
+
+    /**
+     * Cast a list of items to the given class.
+     *
+     * @template T
+     * @param  class-string<T>  $classString
+     * @return T[]
+     */
+    public function castInto(string $name, string $classString): array
+    {
+        $array = $this->list($name) ?? [];
+
+        $result = [];
+
+        foreach ($array as $item) {
+            $result[] = $classString::make($item);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Redirect the call to the underlying result instance.
+     *
+     * @param  array<int, mixed>  $arguments
+     */
+    public function __call(string $method, array $arguments): mixed
+    {
+        return $this->result->$method(...$arguments);
+    }
+}

--- a/src/MnsOpen/Results/MnsResult.php
+++ b/src/MnsOpen/Results/MnsResult.php
@@ -59,6 +59,10 @@ class MnsResult
     {
         $result = $this->get($name);
 
+        if ($result === null) {
+            return null;
+        }
+
         if (! is_array($result)) {
             return [$result];
         }

--- a/src/MnsOpen/Results/PeekMessageResult.php
+++ b/src/MnsOpen/Results/PeekMessageResult.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dew\Acs\MnsOpen\Results;
+
+use Dew\Acs\MnsOpen\Models\PeekMessage;
+
+final class PeekMessageResult extends MnsResult
+{
+    public function message(): PeekMessage
+    {
+        return PeekMessage::make($this->get('Message'));
+    }
+}

--- a/src/MnsOpen/Results/ReceiveMessageResult.php
+++ b/src/MnsOpen/Results/ReceiveMessageResult.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dew\Acs\MnsOpen\Results;
+
+use Dew\Acs\MnsOpen\Models\ReceiveMessage;
+
+final class ReceiveMessageResult extends MnsResult
+{
+    public function message(): ReceiveMessage
+    {
+        return ReceiveMessage::make($this->get('Message'));
+    }
+}

--- a/src/MnsOpen/Results/SendMessageResult.php
+++ b/src/MnsOpen/Results/SendMessageResult.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dew\Acs\MnsOpen\Results;
+
+use Dew\Acs\MnsOpen\Models\SendMessage;
+
+final class SendMessageResult extends MnsResult
+{
+    public function message(): SendMessage
+    {
+        return SendMessage::make($this->get('Message'));
+    }
+}

--- a/src/OpenApi/ApiDocs.php
+++ b/src/OpenApi/ApiDocs.php
@@ -9,12 +9,13 @@ use InvalidArgumentException;
 /**
  * @phpstan-import-type TApi from \Dew\Acs\OpenApi\Api
  * @phpstan-import-type TInfo from \Dew\Acs\OpenApi\Info
+ * @phpstan-type TEndpoint array{regionId: string, endpoint: string}
  * @phpstan-type TApiDocs array{
  *   directories: mixed[][],
  *   info: TInfo,
  *   apis: TApi[],
  *   components: array<string, mixed[]>,
- *   endpoints: mixed[][]
+ *   endpoints: TEndpoint[]
  * }
  *
  * @see https://api.aliyun.com/openmeta/struct/ApiDocs
@@ -24,7 +25,7 @@ final readonly class ApiDocs
     /**
      * @param  TApi[]  $apis
      * @param  mixed[][]  $components
-     * @param  mixed[][]  $endpoints
+     * @param  TEndpoint[]  $endpoints
      */
     public function __construct(
         public Info $info,

--- a/src/ResultProvider.php
+++ b/src/ResultProvider.php
@@ -10,9 +10,6 @@ use Dew\Acs\OpenApi\RefFinder;
 use Dew\Acs\OpenApi\Schema;
 use Psr\Http\Message\ResponseInterface;
 
-/**
- * @phpstan-import-type TError from \Dew\Acs\AcsException
- */
 final readonly class ResultProvider
 {
     private RefFinder $refFinder;
@@ -39,7 +36,6 @@ final readonly class ResultProvider
         $response = new Response($response);
 
         if ($response->isError()) {
-            /** @var \Dew\Acs\Result<TError> $result */
             throw $this->exceptionClass::makeFromResult($result);
         }
 

--- a/src/Sls/SlsException.php
+++ b/src/Sls/SlsException.php
@@ -5,31 +5,16 @@ declare(strict_types=1);
 namespace Dew\Acs\Sls;
 
 use Dew\Acs\AcsException;
-use Dew\Acs\Result;
-use Override;
 
-/**
- * @phpstan-type TError array{
- *   errorCode: string,
- *   errorMessage: string,
- * }
- */
 final class SlsException extends AcsException
 {
     /**
-     * @param  \Dew\Acs\Result<TError>  $result
-     *
-     * @see https://help.aliyun.com/zh/sls/developer-reference/api-sls-2020-12-30-appendix-error-codes
+     * The message field in the error response.
      */
-    #[Override]
-    public static function makeFromResult(Result $result): static
-    {
-        $e = new static(
-            $result->get('errorMessage', 'Could not communicate with Alibaba Cloud.'),
-            $result->get('errorCode', 0)
-        );
+    public const ERROR_MESSAGE = 'errorMessage';
 
-        // @phpstan-ignore argument.type
-        return $e->setResult($result);
-    }
+    /**
+     * The code field in the error response.
+     */
+    public const ERROR_CODE = 'errorCode';
 }

--- a/tests/MnsOpen/Fixtures/StubModel.php
+++ b/tests/MnsOpen/Fixtures/StubModel.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dew\Acs\Tests\MnsOpen\Fixtures;
+
+final readonly class StubModel
+{
+    public function __construct(
+        public string $value
+    ) {
+        //
+    }
+
+    /**
+     * @param  array{value: string}  $data
+     */
+    public static function make(array $data): static
+    {
+        return new static($data['value']);
+    }
+}

--- a/tests/MnsOpen/MnsSignatureTest.php
+++ b/tests/MnsOpen/MnsSignatureTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dew\Acs\Tests\MnsOpen;
+
+use DateTimeInterface;
+use Dew\Acs\MnsOpen\MnsSignature;
+use GuzzleHttp\Psr7\Request;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MnsSignature::class)]
+final class MnsSignatureTest extends TestCase
+{
+    public function test_sign_request(): void
+    {
+        $signature = new MnsSignature();
+        $request = new Request('GET', 'https://example.com');
+        $request = $signature->signRequest($request, ['credentials' => ['key' => 'foo', 'secret' => 'bar']]);
+        $this->assertSame(gmdate(DateTimeInterface::RFC7231), $request->getHeaderLine('date'));
+        $this->assertSame('2015-06-06', $request->getHeaderLine('x-mns-version'));
+        $this->assertStringStartsWith('MNS foo:', $request->getHeaderLine('Authorization'));
+    }
+
+    public function test_canonicalized_headers_headers_are_sorted(): void
+    {
+        $signature = new MnsSignature();
+        $request = new Request('GET', 'https://example.com', ['x-mns-foo' => '1', 'x-mns-bar' => '2']);
+        $result = $signature->canonicalizedHeaders($request);
+        $this->assertSame(<<<'EOF'
+        x-mns-bar:2
+        x-mns-foo:1
+        EOF, $result);
+    }
+
+    public function test_canonicalized_headers_change_cases_before_sorting(): void
+    {
+        $signature = new MnsSignature();
+        $request = new Request('GET', 'https://example.com', ['x-mns-Foo' => '1', 'x-mns-bar' => '2']);
+        $result = $signature->canonicalizedHeaders($request);
+        $this->assertSame(<<<'EOF'
+        x-mns-bar:2
+        x-mns-foo:1
+        EOF, $result);
+    }
+
+    public function test_canonicalized_headers_only_include_mns_headers(): void
+    {
+        $signature = new MnsSignature();
+        $request = new Request('GET', 'https://example.com', ['x-foo' => 'bar']);
+        $result = $signature->canonicalizedHeaders($request);
+        $this->assertSame(<<<'EOF'
+        EOF, $result);
+    }
+
+    public function test_is_mns_header_determines_if_mns_custom_header(): void
+    {
+        $signature = new MnsSignature();
+        $this->assertTrue($signature->isMnsHeader('x-mns-'));
+        $this->assertFalse($signature->isMnsHeader('x-mns'));
+        $this->assertFalse($signature->isMnsHeader('x-mns_'));
+        $this->assertFalse($signature->isMnsHeader('x-acs'));
+        $this->assertFalse($signature->isMnsHeader('x-foo'));
+    }
+}

--- a/tests/MnsOpen/QueueClientTest.php
+++ b/tests/MnsOpen/QueueClientTest.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dew\Acs\Tests\MnsOpen;
+
+use Dew\Acs\MnsOpen\QueueClient;
+use DOMDocument;
+use Http\Mock\Client;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(QueueClient::class)]
+final class QueueClientTest extends TestCase
+{
+    public function test_send_message_sends_message_to_queue(): void
+    {
+        [$mock, $queue] = $this->clients();
+        $queue->sendMessage([
+            'QueueName' => 'testing',
+            'Message' => ['MessageBody' => 'foo'],
+        ]);
+        $request = $mock->getLastRequest();
+        $this->assertSame('POST', $request->getMethod());
+        $this->assertSame('example.com', $request->getUri()->getHost());
+        $this->assertSame('/queues/testing/messages', $request->getUri()->getPath());
+        $this->assertSame($this->xml(<<<'XML'
+        <Message>
+            <MessageBody>foo</MessageBody>
+        </Message>
+        XML), (string) $request->getBody());
+    }
+
+    public function test_sends_message_sends_delay_message(): void
+    {
+        [$mock, $queue] = $this->clients();
+        $queue->sendMessage([
+            'QueueName' => 'testing',
+            'Message' => ['MessageBody' => 'foo', 'DelaySeconds' => 60],
+        ]);
+        $request = $mock->getLastRequest();
+        $this->assertSame($this->xml(<<<'XML'
+        <Message>
+            <MessageBody>foo</MessageBody>
+            <DelaySeconds>60</DelaySeconds>
+        </Message>
+        XML), (string) $request->getBody());
+    }
+
+    public function test_batch_send_message_sends_multiple_messages_to_queue(): void
+    {
+        [$mock, $queue] = $this->clients();
+        $queue->batchSendMessage([
+            'QueueName' => 'testing',
+            'Messages' => [
+                'Message' => [
+                    ['MessageBody' => 'foo'],
+                    ['MessageBody' => 'bar'],
+                ],
+            ],
+        ]);
+        $request = $mock->getLastRequest();
+        $this->assertSame('POST', $request->getMethod());
+        $this->assertSame('example.com', $request->getUri()->getHost());
+        $this->assertSame('/queues/testing/messages', $request->getUri()->getPath());
+        $this->assertSame($this->xml(<<<'XML'
+        <Messages>
+            <Message>
+                <MessageBody>foo</MessageBody>
+            </Message>
+            <Message>
+                <MessageBody>bar</MessageBody>
+            </Message>
+        </Messages>
+        XML), (string) $request->getBody());
+    }
+
+    public function test_batch_send_message_sends_delayed_messages(): void
+    {
+        [$mock, $queue] = $this->clients();
+        $queue->batchSendMessage([
+            'QueueName' => 'testing',
+            'Messages' => [
+                'Message' => [
+                    ['MessageBody' => 'foo'],
+                    ['MessageBody' => 'bar', 'DelaySeconds' => 60],
+                ],
+            ],
+        ]);
+        $request = $mock->getLastRequest();
+        $this->assertSame($this->xml(<<<'XML'
+        <Messages>
+            <Message>
+                <MessageBody>foo</MessageBody>
+            </Message>
+            <Message>
+                <MessageBody>bar</MessageBody>
+                <DelaySeconds>60</DelaySeconds>
+            </Message>
+        </Messages>
+        XML), (string) $request->getBody());
+    }
+
+    public function test_receive_message_receives_message_from_queue(): void
+    {
+        [$mock, $queue] = $this->clients();
+        $queue->receiveMessage(['QueueName' => 'testing']);
+        $request = $mock->getLastRequest();
+        $this->assertSame('GET', $request->getMethod());
+        $this->assertSame('example.com', $request->getUri()->getHost());
+        $this->assertSame('/queues/testing/messages', $request->getUri()->getPath());
+        $this->assertSame('', $request->getUri()->getQuery());
+    }
+
+    public function test_receive_message_configures_long_polling_time(): void
+    {
+        [$mock, $queue] = $this->clients();
+        $queue->receiveMessage(['QueueName' => 'testing', 'waitseconds' => 10]);
+        $request = $mock->getLastRequest();
+        $this->assertSame('waitseconds=10', $request->getUri()->getQuery());
+    }
+
+    public function test_batch_receive_message_receives_multiple_messages_from_queue(): void
+    {
+        [$mock, $queue] = $this->clients();
+        $queue->batchReceiveMessage(['QueueName' => 'testing', 'numOfMessages' => 16]);
+        $request = $mock->getLastRequest();
+        $this->assertSame('GET', $request->getMethod());
+        $this->assertSame('example.com', $request->getUri()->getHost());
+        $this->assertSame('/queues/testing/messages', $request->getUri()->getPath());
+        $this->assertSame('numOfMessages=16', $request->getUri()->getQuery());
+    }
+
+    public function test_batch_receive_message_configures_long_polling_time(): void
+    {
+        [$mock, $queue] = $this->clients();
+        $queue->batchReceiveMessage(['QueueName' => 'testing', 'numOfMessages' => 16, 'waitseconds' => 10]);
+        $request = $mock->getLastRequest();
+        $this->assertSame('numOfMessages=16&waitseconds=10', $request->getUri()->getQuery());
+    }
+
+    public function test_delete_message_deletes_message_from_queue(): void
+    {
+        [$mock, $queue] = $this->clients();
+        $queue->deleteMessage(['QueueName' => 'testing', 'ReceiptHandle' => 'MbZj6wDWli+QEauMZc8ZRv37sIW2iJKq3M9Mx/KSbkJ0']);
+        $request = $mock->getLastRequest();
+        $this->assertSame('DELETE', $request->getMethod());
+        $this->assertSame('example.com', $request->getUri()->getHost());
+        $this->assertSame('/queues/testing/messages', $request->getUri()->getPath());
+        $this->assertSame('ReceiptHandle=MbZj6wDWli+QEauMZc8ZRv37sIW2iJKq3M9Mx/KSbkJ0', $request->getUri()->getQuery());
+    }
+
+    public function test_batch_delete_message_deletes_multiple_messages_from_queue(): void
+    {
+        [$mock, $queue] = $this->clients();
+        $queue->batchDeleteMessage([
+            'QueueName' => 'testing',
+            'ReceiptHandles' => [
+                'ReceiptHandle' => [
+                    '1-ODU4OTkzNDU5My0xNDM1MTk3NjAwLTItNg==',
+                    '1-ODU4OTkzNDU5NC0xNDM1MTk3NjAwLTItNg==',
+                    '1-ODU4OTkzNDU5NS0xNDM1MTk3NjAwLTItNg==',
+                ],
+            ],
+        ]);
+        $request = $mock->getLastRequest();
+        $this->assertSame('DELETE', $request->getMethod());
+        $this->assertSame('example.com', $request->getUri()->getHost());
+        $this->assertSame('/queues/testing/messages', $request->getUri()->getPath());
+        $this->assertSame('', $request->getUri()->getQuery());
+        $this->assertSame($this->xml(<<<'XML'
+        <ReceiptHandles>
+            <ReceiptHandle>1-ODU4OTkzNDU5My0xNDM1MTk3NjAwLTItNg==</ReceiptHandle>
+            <ReceiptHandle>1-ODU4OTkzNDU5NC0xNDM1MTk3NjAwLTItNg==</ReceiptHandle>
+            <ReceiptHandle>1-ODU4OTkzNDU5NS0xNDM1MTk3NjAwLTItNg==</ReceiptHandle>
+        </ReceiptHandles>
+        XML), (string) $request->getBody());
+    }
+
+    public function test_peek_message_peeks_message_from_queue(): void
+    {
+        [$mock, $queue] = $this->clients();
+        $queue->peekMessage(['QueueName' => 'testing']);
+        $request = $mock->getLastRequest();
+        $this->assertSame('GET', $request->getMethod());
+        $this->assertSame('example.com', $request->getUri()->getHost());
+        $this->assertSame('/queues/testing/messages', $request->getUri()->getPath());
+        $this->assertSame('peekonly=true', $request->getUri()->getQuery());
+    }
+
+    public function test_batch_peek_message_peeks_multiple_messages_from_queue(): void
+    {
+        [$mock, $queue] = $this->clients();
+        $queue->batchPeekMessage(['QueueName' => 'testing', 'numOfMessages' => 16]);
+        $request = $mock->getLastRequest();
+        $this->assertSame('GET', $request->getMethod());
+        $this->assertSame('example.com', $request->getUri()->getHost());
+        $this->assertSame('/queues/testing/messages', $request->getUri()->getPath());
+        $this->assertSame('peekonly=true&numOfMessages=16', $request->getUri()->getQuery());
+    }
+
+    public function test_change_message_visibility_updates_message_next_available_time(): void
+    {
+        [$mock, $queue] = $this->clients();
+        $queue->changeMessageVisibility(['QueueName' => 'testing', 'ReceiptHandle' => 'MbZj6wDWli+QEauMZc8ZRv37sIW2iJKq3M9Mx/KSbkJ0', 'VisibilityTimeout' => 60]);
+        $request = $mock->getLastRequest();
+        $this->assertSame('PUT', $request->getMethod());
+        $this->assertSame('example.com', $request->getUri()->getHost());
+        $this->assertSame('/queues/testing/messages', $request->getUri()->getPath());
+        $this->assertSame('receiptHandle=MbZj6wDWli+QEauMZc8ZRv37sIW2iJKq3M9Mx/KSbkJ0&visibilityTimeout=60', $request->getUri()->getQuery());
+    }
+
+    /**
+     * Render the XML document.
+     */
+    private function xml(string $document): string
+    {
+        $xml = new DOMDocument();
+
+        $xml->loadXML(<<<XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        $document
+        XML, LIBXML_NOBLANKS);
+
+        return $xml->saveXML();
+    }
+
+    /**
+     * Create testing clients.
+     *
+     * @return array{0: \Http\Mock\Client, 1: \Dew\Acs\MnsOpen\QueueClient}
+     */
+    private function clients(): array
+    {
+        $mock = new Client();
+
+        $queue = new QueueClient([
+            'credentials' => [
+                'key' => 'foo',
+                'secret' => 'bar',
+            ],
+            'endpoint' => 'https://example.com',
+            'http_client' => $mock,
+        ]);
+
+        return [$mock, $queue];
+    }
+}

--- a/tests/MnsOpen/QueueClientTest.php
+++ b/tests/MnsOpen/QueueClientTest.php
@@ -222,6 +222,7 @@ final class QueueClientTest extends TestCase
         </Error>
         XML)));
         $this->expectException(QueueException::class);
+        $this->expectExceptionMessage('Message not exist.');
         $queue->receiveMessage(['QueueName' => 'testing']);
     }
 

--- a/tests/MnsOpen/QueueClientTest.php
+++ b/tests/MnsOpen/QueueClientTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Dew\Acs\Tests\MnsOpen;
 
 use Dew\Acs\MnsOpen\QueueClient;
+use Dew\Acs\MnsOpen\QueueException;
 use DOMDocument;
+use GuzzleHttp\Psr7\Response;
 use Http\Mock\Client;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -208,6 +210,19 @@ final class QueueClientTest extends TestCase
         $this->assertSame('example.com', $request->getUri()->getHost());
         $this->assertSame('/queues/testing/messages', $request->getUri()->getPath());
         $this->assertSame('receiptHandle=MbZj6wDWli+QEauMZc8ZRv37sIW2iJKq3M9Mx/KSbkJ0&visibilityTimeout=60', $request->getUri()->getQuery());
+    }
+
+    public function test_queue_exception_should_be_thrown_when_error_occurred(): void
+    {
+        [$mock, $queue] = $this->clients();
+        $mock->setDefaultResponse(new Response(404, [], $this->xml(<<<'XML'
+        <Error>
+            <Code>MessageNotExist</Code>
+            <Message>Message not exist.</Message>
+        </Error>
+        XML)));
+        $this->expectException(QueueException::class);
+        $queue->receiveMessage(['QueueName' => 'testing']);
     }
 
     /**

--- a/tests/MnsOpen/QueueExceptionTest.php
+++ b/tests/MnsOpen/QueueExceptionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Dew\Acs\Tests\MnsOpen;
 
 use Dew\Acs\MnsOpen\QueueException;
+use Dew\Acs\MnsOpen\Results\MnsResult;
 use Dew\Acs\Result;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -17,6 +18,7 @@ final class QueueExceptionTest extends TestCase
         $e = QueueException::makeFromResult(new Result(['Error' => ['Code' => 'Unknown', 'Message' => 'Something went wrong!']]));
         $this->assertSame('Something went wrong!', $e->getMessage());
         $this->assertSame('Unknown', $e->getCode());
+        $this->assertInstanceOf(MnsResult::class, $e->getResult());
     }
 
     public function test_result_contains_multiple_error_messages_1_other(): void

--- a/tests/MnsOpen/QueueExceptionTest.php
+++ b/tests/MnsOpen/QueueExceptionTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dew\Acs\Tests\MnsOpen;
+
+use Dew\Acs\MnsOpen\QueueException;
+use Dew\Acs\Result;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(QueueException::class)]
+final class QueueExceptionTest extends TestCase
+{
+    public function test_query_exception_should_be_thrown(): void
+    {
+        $e = QueueException::makeFromResult(new Result(['Error' => ['Code' => 'Unknown', 'Message' => 'Something went wrong!']]));
+        $this->assertSame('Something went wrong!', $e->getMessage());
+        $this->assertSame('Unknown', $e->getCode());
+    }
+
+    public function test_result_contains_multiple_error_messages_1_other(): void
+    {
+        $e = QueueException::makeFromResult(new Result([
+            'Errors' => [
+                'Error' => [
+                    ['ErrorCode' => 'Unknown1', 'ErrorMessage' => 'Something went wrong 1!'],
+                    ['ErrorCode' => 'Unknown2', 'ErrorMessage' => 'Something went wrong 2!'],
+                ],
+            ],
+        ]));
+        $this->assertSame('Something went wrong 1! (and 1 other)', $e->getMessage());
+        $this->assertSame('Unknown1', $e->getCode());
+    }
+
+    public function test_result_contains_multiple_error_messages_2_others(): void
+    {
+        $e = QueueException::makeFromResult(new Result([
+            'Errors' => [
+                'Error' => [
+                    ['ErrorCode' => 'Unknown1', 'ErrorMessage' => 'Something went wrong 1!'],
+                    ['ErrorCode' => 'Unknown2', 'ErrorMessage' => 'Something went wrong 2!'],
+                    ['ErrorCode' => 'Unknown3', 'ErrorMessage' => 'Something went wrong 3!'],
+                ],
+            ],
+        ]));
+        $this->assertSame('Something went wrong 1! (and 2 others)', $e->getMessage());
+        $this->assertSame('Unknown1', $e->getCode());
+    }
+
+    public function test_result_contains_multiple_error_messages_associative_array(): void
+    {
+        $e = QueueException::makeFromResult(new Result([
+            'Errors' => [
+                'Error' => [
+                    'ErrorCode' => 'Unknown1',
+                    'ErrorMessage' => 'Something went wrong 1!',
+                ],
+            ],
+        ]));
+        $this->assertSame('Something went wrong 1!', $e->getMessage());
+        $this->assertSame('Unknown1', $e->getCode());
+    }
+}

--- a/tests/MnsOpen/Results/MnsResultTest.php
+++ b/tests/MnsOpen/Results/MnsResultTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dew\Acs\Tests\MnsOpen\Results;
+
+use Dew\Acs\MnsOpen\Results\MnsResult;
+use Dew\Acs\Result;
+use Dew\Acs\Tests\MnsOpen\Fixtures\StubModel;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MnsResult::class)]
+final class MnsResultTest extends TestCase
+{
+    public function test_list_retrieves_list_array(): void
+    {
+        $result = new MnsResult(new Result(['value' => [1, 2, 3]]));
+        $this->assertSame([1, 2, 3], $result->list('value'));
+    }
+
+    public function test_list_casts_non_array_to_list(): void
+    {
+        $result = new MnsResult(new Result(['value' => 1]));
+        $this->assertSame([1], $result->list('value'));
+    }
+
+    public function test_list_casts_associative_to_list(): void
+    {
+        $result = new MnsResult(new Result(['value' => ['foo' => 'bar']]));
+        $this->assertSame([['foo' => 'bar']], $result->list('value'));
+    }
+
+    public function test_cast_into_casts_items_into_class_through_make_method(): void
+    {
+        $result = new MnsResult(new Result(['data' => ['value' => 'foo']]));
+        $casted = $result->castInto('data', StubModel::class);
+        $this->assertInstanceOf(StubModel::class, $casted[0]);
+        $this->assertSame('foo', $casted[0]->value);
+    }
+
+    public function test_request_id_resolution(): void
+    {
+        $result = new MnsResult((new Result())->setResponse(new Response(200, ['x-mns-request-id' => '512B2A634403E52B1956****'])));
+        $this->assertSame('512B2A634403E52B1956****', $result->requestId());
+    }
+
+    public function test_request_id_returns_null_if_response_is_missing(): void
+    {
+        $result = new MnsResult((new Result())->setResponse(new Response(200)));
+        $this->assertNull($result->requestId());
+    }
+
+    public function test_request_id_returns_null_if_header_is_missing(): void
+    {
+        $result = new MnsResult(new Result());
+        $this->assertNull($result->requestId());
+    }
+
+    public function test_version_resolution(): void
+    {
+        $result = new MnsResult((new Result())->setResponse(new Response(200, ['x-mns-version' => '2015-06-06'])));
+        $this->assertSame('2015-06-06', $result->version());
+    }
+
+    public function test_version_returns_null_if_header_is_missing(): void
+    {
+        $result = new MnsResult((new Result())->setResponse(new Response(200)));
+        $this->assertNull($result->version());
+    }
+
+    public function test_version_returns_null_if_response_is_missing(): void
+    {
+        $result = new MnsResult(new Result());
+        $this->assertNull($result->version());
+    }
+}

--- a/tests/MnsOpen/Results/MnsResultTest.php
+++ b/tests/MnsOpen/Results/MnsResultTest.php
@@ -32,6 +32,12 @@ final class MnsResultTest extends TestCase
         $this->assertSame([['foo' => 'bar']], $result->list('value'));
     }
 
+    public function test_list_returns_null_if_could_not_retrieve_data(): void
+    {
+        $result = new MnsResult(new Result());
+        $this->assertNull($result->list('value'));
+    }
+
     public function test_cast_into_casts_items_into_class_through_make_method(): void
     {
         $result = new MnsResult(new Result(['data' => ['value' => 'foo']]));


### PR DESCRIPTION
The PR implements all supported [client APIs](https://www.alibabacloud.com/help/en/mns/developer-reference/api-overview) for the MNS queue:

- SendMessage
- BatchSendMessage
- ReceiveMessage
- BatchReceiveMessage
- DeleteMessage
- BatchDeleteMessage
- PeekMessage
- BatchPeekMessage
- ChangeMessageVisibility

## Quickstart

Here's a quick demo of configuring an MNS queue and receiving messages from the queue:

```php
use Dew\Acs\MnsOpen\QueueClient;

$client = new QueueClient([
    'credentials' => [
        'key' => 'your-access-key-id',
        'secret' => 'your-access-key-secret',
    ],
    'endpoint' => 'https://your-account-id.mns.cn-shenzhen.aliyuncs.com',
]);

$result = $client->batchReceiveMessage([
    'QueueName' => 'default',
    'numOfMessages' => 16,
]);

foreach ($result->messages() as $message) {
    echo $message->messageBody; // Retrieve the message contents
}

```

The `QueueClient` is designed for managing message interactions with queue instances. Whether you need to create a new queue, clean up and delete an existing one to reduce expenses, or modify queue instance attributes, the `MnsOpenClient` provides the necessary tools.

Client API definitions are not included in OpenMeta; instead, interfaces are hand-crafted to enhance the developer experience. The API attributes and client configuration follow the conventions of the `AcsClient`, minimizing cognitive load and reducing the learning curve.