### PR TITLE
Support for the `simple` style of parameter encoding

### DIFF
--- a/src/OpenApi/RPCStyleBuilder.php
+++ b/src/OpenApi/RPCStyleBuilder.php
@@ -16,6 +16,11 @@ final readonly class RPCStyleBuilder implements ApiDataBuilder
 
     private string $scheme;
 
+    /**
+     * The parameter style encoder.
+     */
+    private StyleEncoder $encoder;
+
     public function __construct(
         private ApiDocs $docs,
         private Api $api
@@ -24,6 +29,8 @@ final readonly class RPCStyleBuilder implements ApiDataBuilder
         $this->scheme = in_array('https', $this->api->schemes, strict: true)
             ? 'https'
             : $this->api->schemes[0];
+
+        $this->encoder = new StyleEncoder();
     }
 
     /**
@@ -94,11 +101,8 @@ final readonly class RPCStyleBuilder implements ApiDataBuilder
         }
 
         return match ($parameter->style) {
-            'repeatList', 'flat' => $this->encodeRepeatListStyle(
-                array_is_list($value) ? $this->shiftKey($value, 1) : $value,
-                $parameter->name
-            ),
-            'json' => $this->encodeJsonStyle($value),
+            'repeatList', 'flat' => $this->encoder->encodeRepeatList($value, $parameter->name),
+            'json' => $this->encoder->encodeJson($value),
             default => $value,
         };
     }
@@ -114,49 +118,5 @@ final readonly class RPCStyleBuilder implements ApiDataBuilder
         }
 
         throw new InvalidArgumentException('Could not encode the query.');
-    }
-
-    /**
-     * @param  array<string, mixed>  $values
-     * @return array<string, mixed>
-     */
-    private function encodeRepeatListStyle(array $values, string $prefix): array
-    {
-        $result = [];
-
-        foreach ($values as $key => $value) {
-            $slug = $prefix.'.'.$key;
-
-            if (is_array($value)) {
-                $result = [...$result, ...$this->encodeRepeatListStyle($value, $slug)];
-            } else {
-                $result[$slug] = $value;
-            }
-        }
-
-        return $result;
-    }
-
-    /**
-     * @param  array<int, mixed>  $values
-     * @return array<int, mixed>
-     */
-    private function shiftKey(array $values, int $offset): array
-    {
-        $result = [];
-
-        foreach ($values as $key => $value) {
-            $result[$key + $offset] = $value;
-        }
-
-        return $result;
-    }
-
-    /**
-     * @param  mixed[]  $data
-     */
-    private function encodeJsonStyle(array $data): string
-    {
-        return json_encode($data, JSON_THROW_ON_ERROR);
     }
 }

--- a/src/OpenApi/RPCStyleBuilder.php
+++ b/src/OpenApi/RPCStyleBuilder.php
@@ -101,6 +101,7 @@ final readonly class RPCStyleBuilder implements ApiDataBuilder
         }
 
         return match ($parameter->style) {
+            'simple' => $this->encoder->encodeSimple($value),
             'repeatList', 'flat' => $this->encoder->encodeRepeatList($value, $parameter->name),
             'json' => $this->encoder->encodeJson($value),
             default => $value,

--- a/src/OpenApi/StyleEncoder.php
+++ b/src/OpenApi/StyleEncoder.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dew\Acs\OpenApi;
+
+final class StyleEncoder
+{
+    /**
+     * Encode data into a JSON string.
+     *
+     * @param  array<mixed>  $data
+     */
+    public function encodeJson(array $data): string
+    {
+        return json_encode($data, JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * Encode data with "dot" notation.
+     *
+     * @param  array<mixed>  $data
+     * @return array<mixed>
+     */
+    public function encodeRepeatList(array $data, string $prefix = ''): array
+    {
+        $result = [];
+
+        foreach ($data as $key => $value) {
+            $slug = $prefix !== '' ? $prefix.'.' : '';
+            $slug .= is_int($key) ? $key + 1 : $key;
+
+            if (is_array($value)) {
+                $result = [...$result, ...$this->encodeRepeatList($value, $slug)];
+            } else {
+                $result[$slug] = $value;
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/OpenApi/StyleEncoder.php
+++ b/src/OpenApi/StyleEncoder.php
@@ -4,8 +4,22 @@ declare(strict_types=1);
 
 namespace Dew\Acs\OpenApi;
 
-final class StyleEncoder
+use Dew\Acs\DataEncoder;
+use Dew\Acs\JsonEncoder;
+use Dew\Acs\XmlEncoder;
+
+final readonly class StyleEncoder
 {
+    /**
+     * Create a new style encoder instance.
+     */
+    public function __construct(
+        private DataEncoder $jsonEncoder = new JsonEncoder(),
+        private DataEncoder $xmlEncoder = new XmlEncoder()
+    ) {
+        //
+    }
+
     /**
      * Encode data into a JSON string.
      *
@@ -13,7 +27,17 @@ final class StyleEncoder
      */
     public function encodeJson(array $data): string
     {
-        return json_encode($data, JSON_THROW_ON_ERROR);
+        return $this->jsonEncoder->encode($data);
+    }
+
+    /**
+     * Encode data into an XML document.
+     *
+     * @param  array<mixed>  $data
+     */
+    public function encodeXml(array $data): string
+    {
+        return $this->xmlEncoder->encode($data);
     }
 
     /**

--- a/src/OpenApi/StyleEncoder.php
+++ b/src/OpenApi/StyleEncoder.php
@@ -39,4 +39,14 @@ final class StyleEncoder
 
         return $result;
     }
+
+    /**
+     * Encode a list of items with a comma character.
+     *
+     * @param  array<int, mixed>  $data
+     */
+    public function encodeSimple(array $data): string
+    {
+        return implode(',', $data);
+    }
 }

--- a/tests/OpenApi/ROAStyleBuilderTest.php
+++ b/tests/OpenApi/ROAStyleBuilderTest.php
@@ -317,6 +317,27 @@ final class ROAStyleBuilderTest extends TestCase
         $this->assertSame('foo', $data->body);
     }
 
+    public function test_parameter_simple_style(): void
+    {
+        $docs = $this->makeApiDocs();
+        $api = $this->makeApi([
+            'parameters' => [[
+                'name' => 'array',
+                'in' => 'query',
+                'style' => 'simple',
+                'schema' => [
+                    'type' => 'array',
+                    'items' => [
+                        'type' => 'string',
+                    ],
+                ],
+            ]],
+        ]);
+        $builder = new ROAStyleBuilder($docs, $api);
+        $data = $builder->build(['array' => ['foo', 'bar']]);
+        $this->assertSame('array=foo%2Cbar', $data->query);
+    }
+
     public function test_parameter_json_style(): void
     {
         $docs = $this->makeApiDocs();

--- a/tests/OpenApi/RPCStyleBuilderTest.php
+++ b/tests/OpenApi/RPCStyleBuilderTest.php
@@ -125,6 +125,27 @@ final class RPCStyleBuilderTest extends TestCase
         );
     }
 
+    public function test_query_resolution_simple_style(): void
+    {
+        $docs = $this->makeApiDocs();
+        $api = $this->makeApi([
+            'parameters' => [[
+                'name' => 'values',
+                'in' => 'query',
+                'style' => 'simple',
+                'schema' => [
+                    'type' => 'array',
+                    'items' => [
+                        'type' => 'string',
+                    ],
+                ],
+            ]],
+        ]);
+        $builder = new RPCStyleBuilder($docs, $api);
+        $argument = $builder->build(['values' => ['foo', 'bar']]);
+        $this->assertSame('values=foo%2Cbar', $argument->query);
+    }
+
     /**
      * @param  mixed[]  $arguments
      */

--- a/tests/OpenApi/StyleEncoderTest.php
+++ b/tests/OpenApi/StyleEncoderTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Dew\Acs\Tests\OpenApi;
 
+use Dew\Acs\DataEncoder;
 use Dew\Acs\OpenApi\StyleEncoder;
+use Mockery;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
@@ -14,9 +16,20 @@ final class StyleEncoderTest extends TestCase
 {
     public function test_encode_json(): void
     {
-        $encoder = new StyleEncoder();
+        $mock = Mockery::mock(DataEncoder::class);
+        $mock->shouldReceive('encode')->once()->andReturn('{"foo":"bar"}');
+        $encoder = new StyleEncoder(jsonEncoder: $mock);
         $result = $encoder->encodeJson(['foo' => 'bar']);
         $this->assertSame('{"foo":"bar"}', $result);
+    }
+
+    public function test_encode_xml(): void
+    {
+        $mock = Mockery::mock(DataEncoder::class);
+        $mock->shouldReceive('encode')->once()->andReturn('<root />');
+        $encoder = new StyleEncoder(xmlEncoder: $mock);
+        $result = $encoder->encodeXml(['root' => []]);
+        $this->assertSame('<root />', $result);
     }
 
     /**

--- a/tests/OpenApi/StyleEncoderTest.php
+++ b/tests/OpenApi/StyleEncoderTest.php
@@ -34,4 +34,11 @@ final class StyleEncoderTest extends TestCase
         $result = $encoder->encodeRepeatList($data);
         $this->assertSame($expected, $result);
     }
+
+    public function test_encode_simple(): void
+    {
+        $encoder = new StyleEncoder();
+        $result = $encoder->encodeSimple(['foo', 2, 3.14]);
+        $this->assertSame('foo,2,3.14', $result);
+    }
 }

--- a/tests/OpenApi/StyleEncoderTest.php
+++ b/tests/OpenApi/StyleEncoderTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dew\Acs\Tests\OpenApi;
+
+use Dew\Acs\OpenApi\StyleEncoder;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(StyleEncoder::class)]
+final class StyleEncoderTest extends TestCase
+{
+    public function test_encode_json(): void
+    {
+        $encoder = new StyleEncoder();
+        $result = $encoder->encodeJson(['foo' => 'bar']);
+        $this->assertSame('{"foo":"bar"}', $result);
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @param  array<string, mixed>  $expected
+     */
+    #[TestWith([['value' => [['name' => 'foo'], ['name' => 'bar']]], ['value.1.name' => 'foo', 'value.2.name' => 'bar']])]
+    #[TestWith([['value' => ['foo', 2, 3.14]], ['value.1' => 'foo', 'value.2' => 2, 'value.3' => 3.14]])]
+    #[TestWith([['foo', 2, 3.14], [1 => 'foo', 2 => 2, 3 => 3.14]])]
+    #[TestWith([['value' => ['foo' => 'bar']], ['value.foo' => 'bar']])]
+    #[TestWith([['value' => 'foo'], ['value' => 'foo']])]
+    public function test_encode_repeat_list(array $data, array $expected): void
+    {
+        $encoder = new StyleEncoder();
+        $result = $encoder->encodeRepeatList($data);
+        $this->assertSame($expected, $result);
+    }
+}


### PR DESCRIPTION
The `simple` style concatenates list items using a comma (,) character. This style can be used in both _ROA_ and _RPC_ style builders. This PR also refactors the style encoding logic into a dedicated reusable class.